### PR TITLE
Add helper function FindAllEntitiesByDesignerName

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -426,6 +426,16 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+        public static IntPtr GetFirstActiveEntity(){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x3E50DC41);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			}
+		}
+
         public static void HookEvent(string name, InputArgument callback, bool ispost){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();

--- a/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
@@ -21,6 +21,8 @@ public partial class CEntityIdentity
     public unsafe CEntityInstance EntityInstance => new(Unsafe.Read<IntPtr>((void*)Handle));
     public unsafe CHandle<CEntityInstance> EntityHandle => new(Handle + 0x10);
     public unsafe string DesignerName => ReadStringUtf8(Handle + 0x20);
+    public unsafe PointerTo<CEntityIdentity> Prev => new (Handle + 0x58);
+    public unsafe PointerTo<CEntityIdentity> Next => new(Handle + 0x60);
 
     // TODO: Move this method to a shared marshalling lib
     public unsafe string ReadStringUtf8(IntPtr ptr)

--- a/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
@@ -21,7 +21,7 @@ public partial class CEntityIdentity
     public unsafe CEntityInstance EntityInstance => new(Unsafe.Read<IntPtr>((void*)Handle));
     public unsafe CHandle<CEntityInstance> EntityHandle => new(Handle + 0x10);
     public unsafe string DesignerName => ReadStringUtf8(Handle + 0x20);
-    public unsafe PointerTo<CEntityIdentity> Prev => new (Handle + 0x58);
+    public unsafe PointerTo<CEntityIdentity> Prev => new(Handle + 0x58);
     public unsafe PointerTo<CEntityIdentity> Next => new(Handle + 0x60);
 
     // TODO: Move this method to a shared marshalling lib

--- a/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
@@ -23,6 +23,8 @@ public partial class CEntityIdentity
     public unsafe string DesignerName => ReadStringUtf8(Handle + 0x20);
     public unsafe PointerTo<CEntityIdentity> Prev => new(Handle + 0x58);
     public unsafe PointerTo<CEntityIdentity> Next => new(Handle + 0x60);
+    public unsafe PointerTo<CEntityIdentity> PrevByClass => new(Handle + 0x68);
+    public unsafe PointerTo<CEntityIdentity> NextByClass => new(Handle + 0x70);
 
     // TODO: Move this method to a shared marshalling lib
     public unsafe string ReadStringUtf8(IntPtr ptr)

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -15,6 +15,7 @@
  */
 
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,25 +39,13 @@ namespace CounterStrikeSharp.API
         {
             var entList = new List<CEntityInstance>();
 
-            // Start at worldent - index 0. This should always exist.
-            var pEntity = new CEntityInstance(NativeAPI.GetEntityFromIndex(0)).m_pEntity.Value;
+            var pEntity = new CEntityIdentity(NativeAPI.GetFirstActiveEntity());
             for (; pEntity.Handle != IntPtr.Zero; pEntity = pEntity.Next.Value)
             {
-                Console.WriteLine(pEntity.DesignerName);
                 if (!pEntity.DesignerName.Contains(designerName)) continue;
-                entList.Add(new CEntityInstance(pEntity.Handle));
+                entList.Add(new PointerTo<CEntityInstance>(pEntity.Handle).Value);
             }
 
-            /*
-            for (int i = 0; i < MaxEdicts; i++)
-            {
-                var entPtr = NativeAPI.GetEntityFromIndex(i);
-                if (entPtr == IntPtr.Zero) continue;
-                var ent = new CEntityInstance(entPtr);
-                if (!ent.DesignerName.Contains(designerName)) continue;
-
-                entList.Add(ent);
-            }*/
             return entList.AsEnumerable<CEntityInstance>();
         }
     }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -37,6 +37,17 @@ namespace CounterStrikeSharp.API
         public static IEnumerable<CEntityInstance> FindAllEntitiesByDesignerName(string designerName)
         {
             var entList = new List<CEntityInstance>();
+
+            // Start at worldent - index 0. This should always exist.
+            var pEntity = new CEntityInstance(NativeAPI.GetEntityFromIndex(0)).m_pEntity.Value;
+            for (; pEntity.Handle != IntPtr.Zero; pEntity = pEntity.Next.Value)
+            {
+                Console.WriteLine(pEntity.DesignerName);
+                if (!pEntity.DesignerName.Contains(designerName)) continue;
+                entList.Add(new CEntityInstance(pEntity.Handle));
+            }
+
+            /*
             for (int i = 0; i < MaxEdicts; i++)
             {
                 var entPtr = NativeAPI.GetEntityFromIndex(i);
@@ -45,8 +56,8 @@ namespace CounterStrikeSharp.API
                 if (!ent.DesignerName.Contains(designerName)) continue;
 
                 entList.Add(ent);
-            }
-            return entList.AsEnumerable<CEntityInstance>(); 
+            }*/
+            return entList.AsEnumerable<CEntityInstance>();
         }
     }
 }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -17,7 +17,6 @@
 using CounterStrikeSharp.API.Core;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace CounterStrikeSharp.API

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -14,8 +14,10 @@
  *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
  */
 
+using CounterStrikeSharp.API.Core;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace CounterStrikeSharp.API
@@ -31,6 +33,21 @@ namespace CounterStrikeSharp.API
         {
             return Enum.GetValues(typeof(T)).Cast<T>()
                 .Where(x => flags.HasFlag(x)).AsEnumerable();
+        }
+
+        public static List<CEntityInstance> FindAllEntitiesByDesignerName(string designerName)
+        {
+            var entList = new List<CEntityInstance>();
+            for (int i = 0; i < MaxEdicts; i++)
+            {
+                var entPtr = NativeAPI.GetEntityFromIndex(i);
+                if (entPtr == IntPtr.Zero) continue;
+                var ent = new CEntityInstance(entPtr);
+                if (!ent.DesignerName.Contains(designerName)) continue;
+
+                entList.Add(ent);
+            }
+            return entList; 
         }
     }
 }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -35,18 +35,14 @@ namespace CounterStrikeSharp.API
                 .Where(x => flags.HasFlag(x)).AsEnumerable();
         }
 
-        public static IEnumerable<CEntityInstance> FindAllEntitiesByDesignerName(string designerName)
+        public static IEnumerable<T> FindAllEntitiesByDesignerName<T>(string designerName) where T : CEntityInstance
         {
-            var entList = new List<CEntityInstance>();
-
             var pEntity = new CEntityIdentity(NativeAPI.GetFirstActiveEntity());
             for (; pEntity.Handle != IntPtr.Zero; pEntity = pEntity.Next.Value)
             {
                 if (!pEntity.DesignerName.Contains(designerName)) continue;
-                entList.Add(new PointerTo<CEntityInstance>(pEntity.Handle).Value);
+                yield return new PointerTo<T>(pEntity.Handle).Value;
             }
-
-            return entList.AsEnumerable<CEntityInstance>();
         }
     }
 }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -34,7 +34,7 @@ namespace CounterStrikeSharp.API
                 .Where(x => flags.HasFlag(x)).AsEnumerable();
         }
 
-        public static List<CEntityInstance> FindAllEntitiesByDesignerName(string designerName)
+        public static IEnumerable<CEntityInstance> FindAllEntitiesByDesignerName(string designerName)
         {
             var entList = new List<CEntityInstance>();
             for (int i = 0; i < MaxEdicts; i++)
@@ -46,7 +46,7 @@ namespace CounterStrikeSharp.API
 
                 entList.Add(ent);
             }
-            return entList; 
+            return entList.AsEnumerable<CEntityInstance>(); 
         }
     }
 }

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -83,13 +83,25 @@ namespace TestPlugin
             });
             RegisterEventHandler<EventRoundStart>(@event =>
             {
-                var playerEntities = Utilities.FindAllEntitiesByDesignerName("cs_player_controller");
-                Log($"cs_player_controller count: {playerEntities.Count<CEntityInstance>()}");
+                // Grab all cs_player_controller entities and set their cash value to $1337.
+                var playerEntities = Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller");
+                Log($"cs_player_controller count: {playerEntities.Count<CCSPlayerController>()}");
 
-                foreach (var entInst in playerEntities)
+                foreach (var player in playerEntities)
                 {
-                    var player = new CCSPlayerController(entInst.Handle);
+                    //var player = new CCSPlayerController(entInst.Handle);
                     player.m_pInGameMoneyServices.Value.m_iAccount = 1337;
+                }
+
+                // Grab everything starting with cs_, but we'll only mainpulate cs_gamerules.
+                var csEntities = Utilities.FindAllEntitiesByDesignerName<CBaseEntity>("cs_");
+                Log($"Amount of cs_* entities: {csEntities.Count<CBaseEntity>()}");
+
+                foreach (var entity in csEntities)
+                {
+                    if (entity.DesignerName != "cs_gamerules") continue;
+                    var gamerulesEnt = new CCSGameRules(entity.Handle);
+                    gamerulesEnt.m_bCTTimeOutActive = true;
                 }
             });
 

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
@@ -82,11 +83,11 @@ namespace TestPlugin
             RegisterEventHandler<EventRoundStart>(@event =>
             {
                 var playerEntities = Utilities.FindAllEntitiesByDesignerName("cs_player_controller");
-                Log($"cs_player_controller count: {playerEntities.Count}");
+                Log($"cs_player_controller count: {playerEntities.Count<CEntityInstance>()}");
 
-                foreach (var ents in playerEntities)
+                foreach (var entInst in playerEntities)
                 {
-                    var player = new CCSPlayerController(ents.Handle);
+                    var player = new CCSPlayerController(entInst.Handle);
                     player.m_pInGameMoneyServices.Value.m_iAccount = 1337;
                 }
             });

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -24,6 +24,7 @@ using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Entities;
 using CounterStrikeSharp.API.Modules.Events;
 using CounterStrikeSharp.API.Modules.Memory;
+using CounterStrikeSharp.API.Modules.Utils;
 
 namespace TestPlugin
 {
@@ -105,6 +106,7 @@ namespace TestPlugin
 
             RegisterListener<Listeners.OnEntitySpawned>(entity =>
             {
+
                 var designerName = entity.DesignerName;
                 if (designerName != "smokegrenade_projectile") return;
 

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -79,6 +79,17 @@ namespace TestPlugin
                     $"Found steamID {new SteamID(player.m_steamID)} for player {player.m_iszPlayerName}:{pawn.m_iHealth}|{pawn.m_bInBuyZone}");
                 Log($"{@event.Userid}, {@event.X},{@event.Y},{@event.Z}");
             });
+            RegisterEventHandler<EventRoundStart>(@event =>
+            {
+                var playerEntities = Utilities.FindAllEntitiesByDesignerName("cs_player_controller");
+                Log($"cs_player_controller count: {playerEntities.Count}");
+
+                foreach (var ents in playerEntities)
+                {
+                    var player = new CCSPlayerController(ents.Handle);
+                    player.m_pInGameMoneyServices.Value.m_iAccount = 1337;
+                }
+            });
 
             // Hook global listeners defined by CounterStrikeSharp
             RegisterListener<Listeners.OnMapStart>(mapName => { Log($"Map {mapName} has started!"); });

--- a/src/scripting/natives/natives_entities.cpp
+++ b/src/scripting/natives/natives_entities.cpp
@@ -60,6 +60,10 @@ void PrintToConsole(ScriptContext& scriptContext) {
     globals::engine->ClientPrintf(CPlayerSlot{index - 1}, message);
 }
 
+CEntityIdentity* GetFirstActiveEntity(ScriptContext& script_context) {
+    return globals::entitySystem->m_EntityList.m_pFirstActiveEntity;
+}
+
 REGISTER_NATIVES(entities, {
     ScriptEngine::RegisterNativeHandler("GET_ENTITY_FROM_INDEX", GetEntityFromIndex);
     ScriptEngine::RegisterNativeHandler("GET_USERID_FROM_INDEX", GetUserIdFromIndex);
@@ -67,5 +71,6 @@ REGISTER_NATIVES(entities, {
     ScriptEngine::RegisterNativeHandler("GET_ENTITY_POINTER_FROM_HANDLE",
                                         GetEntityPointerFromHandle);
     ScriptEngine::RegisterNativeHandler("PRINT_TO_CONSOLE", PrintToConsole);
+    ScriptEngine::RegisterNativeHandler("GET_FIRST_ACTIVE_ENTITY", GetFirstActiveEntity);
 })
 }  // namespace counterstrikesharp

--- a/src/scripting/natives/natives_entities.yaml
+++ b/src/scripting/natives/natives_entities.yaml
@@ -3,3 +3,4 @@ GET_USERID_FROM_INDEX: index:int -> int
 GET_DESIGNER_NAME: pointer:pointer -> string
 GET_ENTITY_POINTER_FROM_HANDLE: entityHandlePointer:pointer -> pointer
 PRINT_TO_CONSOLE: index:int, message:string -> void
+GET_FIRST_ACTIVE_ENTITY: -> pointer


### PR DESCRIPTION
The goal of this PR is to add a function that allows plugins to grab a list of all entities with a certain design name so they can be easily manipulated. The example I've used is setting all of the player's money value to 1337.

This could be optimized, but this will require further work internally which I'm not confident with. Right now the function loops through all 16k entity indexes, but this can probably be cut down using the method [CS2Fixes uses by navigating through entity pointers until they run into a null pointer](https://github.com/Source2ZE/CS2Fixes/blob/main/src/utils/entity.cpp#L29). It would be possible to do the basic functionality on the C++ side, but I prefer the design of returning a List, and returning an array from the C++ side isn't easy as I've been told. A feature I would like to in-cooperate into this function is passing through a type (e.g `Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller")`) so you can just manipulate all of the entities in the list straight away. I tried doing this, but ran into errors related to `new T()`. My C# knowledge isn't strong so I've abandoned this idea for now and instead return a `List<CEntityInstance>`.