### PR TITLE
add libicu readme hint

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,5 +4,6 @@
 2. Download the latest release of CounterStrikeSharp from [here](https://github.com/roflmuffin/CounterStrikeSharp/actions/workflows/cmake-single-platform.yml).
    - If this is your first time installing, you will need to download the `with-runtime` version. This includes the .NET runtime, which is required to run the plugin.
    - Subsequent upgrades will not require the runtime, unless a version bump of the .NET runtime is required (i.e. from 7.0.x to 8.0.x).
+   - Depending on the os you might also need to install `libicu` / `icu-libs` / `libicu-dev` using your package manager for .NET to run.
 3. Extract the `addons` folder to the `/csgo/` directory of the dedicated server.
 4. Start the server. If everything is working correctly, you should see a message in the console that says `CounterStrikeSharp.API Loaded Successfully.`

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -15,6 +15,7 @@ Download the latest release of CounterStrikeSharp from <a href="https://github.c
 
 :::caution[.NET Runtime]
 If this is your first time installing, you will need to download the `with-runtime` version. This includes a copy of the .NET runtime, which is required to run the plugin.
+Depending on the os you might also need to install `libicu` / `icu-libs` / `libicu-dev` using your package manager for .NET to run.
 
 Subsequent upgrades will not require the runtime, unless a version bump of the .NET runtime is required (i.e. from 7.0.x to 8.0.x). We will inform you when this occurs.
 :::


### PR DESCRIPTION
when using docker (debian bullseye) to run CounterStrikeSharp, the process terminates with the error
```
[19:03:34.187] CSSharp: .NET Runtime Initialised.
Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu (or icu-libs) using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
   at System.Environment.FailFast(System.String)
   at System.Globalization.GlobalizationMode+Settings..cctor()
   at System.Globalization.CultureData.CreateCultureWithInvariantData()
   at System.Globalization.CultureData.get_Invariant()
   at System.Globalization.CultureInfo..cctor()
   at System.Globalization.CompareInfo..cctor()
   at System.CultureAwareComparer..cctor()
   at Internal.Runtime.InteropServices.ComponentActivator..cctor()
   at Internal.Runtime.InteropServices.ComponentActivator.LoadAssemblyAndGetFunctionPointer(IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr)
```
so it is required to install libicu to the system. I thought this hint would be a good thing in the readme.