### PR TITLE
feat: Adds Chat Triggers for Console Commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ add_subdirectory(libraries/spdlog)
 add_subdirectory(libraries/dyncall)
 add_subdirectory(libraries/funchook)
 
+set_property(TARGET funchook-static PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 SET(SOURCE_FILES
         src/mm_plugin.cpp
         src/mm_plugin.h
@@ -68,6 +70,8 @@ SET(SOURCE_FILES
         src/scripting/natives/natives_entities.cpp
         src/core/managers/entity_manager.cpp
         src/core/managers/entity_manager.h
+        src/core/managers/chat_manager.cpp
+        src/core/managers/chat_manager.h
 )
 
 set(PROTO_DIRS -I${CMAKE_CURRENT_SOURCE_DIR}/libraries/GameTracking-CS2/Protobufs)

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -217,6 +217,19 @@ namespace TestPlugin
             Log("cssharp_attribute called!");
         }
 
+        [ConsoleCommand("guns", "List guns")]
+        public void OnCommandGuns(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player == null) return;
+            if (!player.PlayerPawn.IsValid) return;
+            
+            foreach (var weapon in player.PlayerPawn.Value.WeaponServices.MyWeapons)
+            {
+                // We don't currently have a `ReplyToCommand` equivalent so just print to chat for now.
+                player.PrintToChat(weapon.Value.DesignerName);
+            }
+        }
+
         private HookResult GenericEventHandler<T>(T @event, GameEventInfo info) where T : GameEvent
         {
             Log($"Event found {@event.Handle:X}, event name: {@event.EventName} dont broadcast: {info.DontBroadcast}");

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -13,6 +13,7 @@
 #include "log.h"
 #include "utils/virtual.h"
 #include "core/managers/con_command_manager.h"
+#include "core/managers/chat_manager.h"
 #include "memory_module.h"
 #include "interfaces/cs2_interfaces.h"
 #include "core/managers/entity_manager.h"
@@ -68,6 +69,7 @@ PlayerManager playerManager;
 TimerSystem timerSystem;
 ConCommandManager conCommandManager;
 EntityManager entityManager;
+ChatManager chatManager;
 
 void Initialize() {
     modules::engine = new modules::CModule(ROOTBIN, "engine2");

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#define protected public
+#define private public
+#include <tier1/convar.h>
+#undef protected
+#undef private
+
 #include "ISmmAPI.h"
 #include "eiface.h"
 #include "iserver.h"
@@ -41,6 +47,7 @@ class TimerSystem;
 class ChatCommands;
 class HookManager;
 class EntityManager;
+class ChatManager;
 
 namespace globals {
 
@@ -81,6 +88,8 @@ extern MenuManager menuManager;
 extern EntityManager entityManager;
 extern TimerSystem timerSystem;
 extern ChatCommands chatCommands;
+extern ChatManager chatManager;
+
 extern HookManager hookManager;
 extern SourceHook::ISourceHook *source_hook;
 extern int source_hook_pluginid;

--- a/src/core/managers/chat_manager.cpp
+++ b/src/core/managers/chat_manager.cpp
@@ -1,0 +1,98 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
+ */
+
+#include "core/managers/chat_manager.h"
+#include "core/managers/con_command_manager.h"
+#include "scripting/callback_manager.h"
+#include "characterset.h"
+
+#include <baseentity.h>
+#include <public/eiface.h>
+#include "core/memory.h"
+
+#include <funchook.h>
+
+namespace counterstrikesharp {
+
+ChatManager::ChatManager() {}
+
+ChatManager::~ChatManager() {}
+
+void ChatManager::OnAllInitialized()
+{
+    // TODO: Allow reading of the shared game data json from the C++ side too so this isn't
+    // being hardcoded.
+    m_pHostSay = (HostSay)FindSignature(
+        MODULE_PREFIX "server" MODULE_EXT,
+        R"(\x55\x48\x89\xE5\x41\x57\x49\x89\xFF\x41\x56\x41\x55\x41\x54\x4D\x89\xC4)");
+
+    auto m_hook = funchook_create();
+    funchook_prepare(m_hook, (void**)&m_pHostSay, (void*)&DetourHostSay);
+    funchook_install(m_hook, 0);
+}
+
+void ChatManager::OnShutdown() {}
+
+void DetourHostSay(CBaseEntity* pController, CCommand& args, bool teamonly, int unk1,
+                   const char* unk2)
+{
+    CCommand newArgs;
+    newArgs.Tokenize(args.Arg(1));
+
+    if (*args[1] == '/' || *args[1] == '!') {
+        globals::chatManager.OnSayCommandPost(pController, newArgs);
+        return;
+    }
+
+    m_pHostSay(pController, args, teamonly, unk1, unk2);
+}
+
+bool ChatManager::OnSayCommandPre(CBaseEntity* pController, CCommand& command) {}
+
+bool ChatManager::OnSayCommandPost(CBaseEntity* pController, CCommand& command)
+{
+    const char* args = command.ArgS();
+    auto commandStr = command.Arg(0);
+
+    return InternalDispatch(pController, commandStr + 1, command);
+}
+
+bool ChatManager::InternalDispatch(CBaseEntity* pPlayerController, const char* szTriggerPhase,
+                                   CCommand& fullCommand)
+{
+    auto ppArgV = new const char*[fullCommand.ArgC()];
+    ppArgV[0] = strdup(szTriggerPhase);
+    for (int i = 1; i < fullCommand.ArgC(); i++) {
+        ppArgV[i] = fullCommand.Arg(i);
+    }
+
+    CCommand commandCopy(fullCommand.ArgC(), ppArgV);
+
+    if (pPlayerController == nullptr) {
+        auto result = globals::conCommandManager.InternalDispatch(CPlayerSlot(-1), &commandCopy);
+        delete[] ppArgV;
+        return result;
+    }
+
+    auto index = pPlayerController->GetEntityIndex().Get();
+
+    auto slot = CPlayerSlot(index - 1);
+
+    auto result = globals::conCommandManager.InternalDispatch(slot, &commandCopy);
+    delete[] ppArgV;
+    return result;
+}
+} // namespace counterstrikesharp

--- a/src/core/managers/chat_manager.h
+++ b/src/core/managers/chat_manager.h
@@ -1,0 +1,70 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
+ */
+
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include "core/globals.h"
+#include "core/global_listener.h"
+#include "scripting/script_engine.h"
+
+namespace counterstrikesharp {
+class ScriptCallback;
+
+typedef void (*HostSay)(CBaseEntity*, CCommand&, bool, int, const char*);
+
+class ChatCommandInfo
+{
+    friend class ChatManager;
+
+  public:
+    ChatCommandInfo() {}
+
+  public:
+    ScriptCallback* GetCallback() { return callback_pre; }
+
+  private:
+    std::string command;
+    ScriptCallback* callback_pre;
+    ScriptCallback* callback_post;
+};
+
+class ChatManager : public GlobalClass
+{
+  public:
+    ChatManager();
+    ~ChatManager();
+    void OnAllInitialized() override;
+    void OnShutdown() override;
+
+    bool OnSayCommandPre(CBaseEntity* pController, CCommand& args);
+    bool OnSayCommandPost(CBaseEntity* pController, CCommand& args);
+
+  private:
+    bool InternalDispatch(CBaseEntity* pPlayerController, const char* szTriggerPhrase,
+                          CCommand& pFullCommand);
+
+    std::vector<ChatCommandInfo*> m_cmd_list;
+    std::map<std::string, ChatCommandInfo*> m_cmd_lookup;
+};
+
+static void DetourHostSay(CBaseEntity* pController, CCommand& args, bool teamonly, int unk1,
+                          const char* unk2);
+static HostSay m_pHostSay = nullptr;
+
+} // namespace counterstrikesharp

--- a/src/core/managers/con_command_manager.cpp
+++ b/src/core/managers/con_command_manager.cpp
@@ -128,7 +128,6 @@ ConCommandInfo* ConCommandManager::AddOrFindCommand(const char* name,
             CSSHARP_CORE_TRACE("[ConCommandManager] Creating callbacks for command {}", name);
 
             p_info->command = conCommand;
-            p_info->sdn = true;
             p_info->callback_pre = globals::callbackManager.CreateCallback(name);
             p_info->callback_post = globals::callbackManager.CreateCallback(name);
             p_info->server_only = server_only;
@@ -217,17 +216,15 @@ ConCommandInfo* ConCommandManager::FindCommand(const char* name) {
         if (!p_cmd.IsValid()) return nullptr;
 
         p_info = new ConCommandInfo();
+        p_info->command = globals::cvars->GetCommand(p_cmd);
 
+        p_info->p_cmd = *p_info->command->GetRef();
         p_info->callback_pre = globals::callbackManager.CreateCallback(name);
         p_info->callback_post = globals::callbackManager.CreateCallback(name);
         p_info->server_only = false;
 
-        if (p_cmd.IsValid()) {
-            // p_info->p_cmd = p_cmd.IsValid()
-
-            m_cmd_list.push_back(p_info);
-            m_cmd_lookup[name] = p_info;
-        }
+        m_cmd_list.push_back(p_info);
+        m_cmd_lookup[name] = p_info;
 
         return p_info;
     }
@@ -252,6 +249,10 @@ bool ConCommandManager::InternalDispatch(CPlayerSlot slot, const CCommand* args)
                 continue;
             }
         }
+    }
+
+    if (!p_info) {
+        return false;
     }
 
     int realClient = slot.Get();

--- a/src/core/managers/con_command_manager.h
+++ b/src/core/managers/con_command_manager.h
@@ -60,7 +60,6 @@ public:
     ScriptCallback* GetCallback() { return callback_pre; }
 
 private:
-    bool sdn;
     ConCommandRefAbstract p_cmd;
     ConCommand* command;
     ScriptCallback* callback_pre;

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -13,3 +13,4 @@
 #define MODULE_EXT ".so"
 
 int GetModuleInformation(void *hModule, void **base, size_t *length);
+void* FindSignature(const char* moduleName, const char* bytesStr);


### PR DESCRIPTION
Adds chat triggers for console commands with `/` and `!` characters. E.g. The below command is triggerable from console typing `guns` or also from chat typing `!guns` and `/guns`. All chat is prevented from sending if it starts with the trigger phrases (no public commands at this stage).

```csharp
[ConsoleCommand("guns", "List guns")]
public void OnCommandGuns(CCSPlayerController? player, CommandInfo command)
{
    if (player == null) return;
    if (!player.PlayerPawn.IsValid) return;
    
    foreach (var weapon in player.PlayerPawn.Value.WeaponServices.MyWeapons)
    {
        // We don't currently have a `ReplyToCommand` equivalent so just print to chat for now.
        player.PrintToChat(weapon.Value.DesignerName);
    }
}
```