### PR TITLE
Add css, css_plugins commands.

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/GlobalContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/GlobalContext.cs
@@ -122,7 +122,6 @@ namespace CounterStrikeSharp.API.Core
 
             foreach (var path in filePaths)
             {
-                if (path.Contains("disabled")) continue;
                 try
                 {
                     LoadPlugin(path);

--- a/managed/CounterStrikeSharp.API/Core/GlobalContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/GlobalContext.cs
@@ -80,23 +80,15 @@ namespace CounterStrikeSharp.API.Core
         {
             var plugin = new PluginContext(path);
 
-            try
+            foreach (var existingPlugin in _loadedPlugins)
             {
-                foreach (var existingPlugin in _loadedPlugins)
+                if (plugin.Name == existingPlugin.Name)
                 {
-                    if (plugin.Name == existingPlugin.Name)
-                    {
-                        throw new Exception("Plugin is already loaded.");
-                    }
+                    throw new Exception("Plugin is already loaded.");
                 }
-                _loadedPlugins.Add(plugin);
-                plugin.Load();
             }
-            catch (Exception e)
-            {
-                _loadedPlugins.Remove(plugin);
-                throw;
-            }
+            plugin.Load();
+            _loadedPlugins.Add(plugin);
         }
 
         public int LoadAllPlugins()

--- a/managed/CounterStrikeSharp.API/Core/Helpers.cs
+++ b/managed/CounterStrikeSharp.API/Core/Helpers.cs
@@ -59,7 +59,7 @@ namespace CounterStrikeSharp.API.Core
             try
             {
                 var globalContext = new GlobalContext();
-                globalContext.LoadAll();
+                globalContext.InitGlobalContext();
                 return 1;
             }
             catch (Exception e)

--- a/managed/CounterStrikeSharp.API/Core/PluginContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/PluginContext.cs
@@ -31,13 +31,17 @@ namespace CounterStrikeSharp.API.Core
         public string Name => _plugin?.ModuleName;
         public string Version => _plugin?.ModuleVersion;
         public Type PluginType => _plugin?.GetType();
+        public string PluginPath => _plugin?.ModulePath;
+
+        public int PluginId { get; }
 
         private readonly string _path;
         private readonly FileSystemWatcher _fileWatcher;
 
-        public PluginContext(string path)
+        public PluginContext(string path, int id)
         {
             _path = path;
+            PluginId = id;
 
             _assemblyLoader = PluginLoader.CreateFromAssemblyFile(path, new[] { typeof(IPlugin) }, config =>
             {

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -47,7 +47,20 @@ namespace CounterStrikeSharp.API
                 yield return new PointerTo<T>(pEntity.Handle).Value;
             }
         }
-        
+
+        public static void ReplyToCommand(CCSPlayerController? player, string msg, bool console = false)
+        {
+            if (player != null)
+            {
+                if (console) player.PrintToConsole(msg);
+                else player.PrintToChat(msg);
+            }
+            else
+            {
+                Server.PrintToConsole(msg);
+            }
+        }
+
         public static unsafe string ReadStringUtf8(IntPtr ptr)
         {
             unsafe


### PR DESCRIPTION
This PR adds two new commands: `css`, and `css_plugins`.
- `css` displays credits (mainly towards roflmuffin) and points towards the acknowledgements file.
- `css_plugins` handles plugin loading, unloading, reloading, and displaying a list of plugins.
I've also moved a few things around in `GlobalContext`: renamed `LoadAll` to `InitGlobalContext`, and split some functions into smaller ones.

I decided to deviate from the MetaMod/SourceMod style of "self-command" and split plugins into it's own isolated category of commands. I did this for future development, like possibly incooperating `apfelwurm` 's [update/install commands](https://discord.com/channels/1160907911501991946/1160907912445710481/1166516777925222400) into it's own category.