### PR TITLE
feat: add `MinimumApiVersion` attribute

### DIFF
--- a/managed/CounterStrikeSharp.API/Api.cs
+++ b/managed/CounterStrikeSharp.API/Api.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using CounterStrikeSharp.API.Core;
+
+namespace CounterStrikeSharp.API;
+
+public class Api
+{
+    /// <summary>
+    /// Returns the API version of CounterStrikeSharp running on the server
+    /// </summary>
+    /// <returns></returns>
+    public static int GetVersion()
+    {
+        return Assembly.GetAssembly(typeof(BasePlugin))!.GetName().Version!.Build;
+    }
+}

--- a/managed/CounterStrikeSharp.API/Core/Attributes/MinimumApiVersionAttribute.cs
+++ b/managed/CounterStrikeSharp.API/Core/Attributes/MinimumApiVersionAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace CounterStrikeSharp.API.Core.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class MinimumApiVersion : System.Attribute
+{
+    public int Version { get; }
+
+    /// <summary>
+    /// API version that this plugin requires to work correctly.
+    /// </summary>
+    /// <param name="version"></param>
+    public MinimumApiVersion(int version)
+    {
+        this.Version = version;
+    }
+}

--- a/managed/CounterStrikeSharp.API/Core/PluginContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/PluginContext.cs
@@ -17,7 +17,9 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using CounterStrikeSharp.API.Core.Attributes;
 using CounterStrikeSharp.API.Modules.Events;
 using McMaster.NETCore.Plugins;
 
@@ -88,6 +90,14 @@ namespace CounterStrikeSharp.API.Core
                     .FirstOrDefault(t => typeof(IPlugin).IsAssignableFrom(t));
 
                 if (pluginType == null) throw new Exception("Unable to find plugin in DLL");
+
+                var minimumApiVersion = pluginType.GetCustomAttribute<MinimumApiVersion>()?.Version;
+                var currentVersion = Api.GetVersion();
+                
+                // Ignore version 0 for local development
+                if (currentVersion > 0 && minimumApiVersion != null && minimumApiVersion > currentVersion)
+                    throw new Exception(
+                        $"Plugin \"{Path.GetFileName(_path)}\" requires a newer version of CounterStrikeSharp. The plugin expects version [{minimumApiVersion}] but the current version is [{currentVersion}].");
 
                 Console.WriteLine($"Loading plugin: {pluginType.Name}");
                 _plugin = (BasePlugin)Activator.CreateInstance(pluginType)!;

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Cvars;
@@ -30,6 +31,7 @@ using CounterStrikeSharp.API.Modules.Utils;
 
 namespace TestPlugin
 {
+    [MinimumApiVersion(1)]
     public class SamplePlugin : BasePlugin
     {
         public override string ModuleName => "Sample Plugin";


### PR DESCRIPTION
Adds a `MinimumApiVersion` attribute which will fail the loading of a plugin if the version running on the server is lower than the required version.