### PR TITLE
Remove required from flags in AdminData

### DIFF
--- a/managed/CounterStrikeSharp.API/Modules/Admin/AdminPermissions.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Admin/AdminPermissions.cs
@@ -16,7 +16,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
     public partial class AdminData
     {
         [JsonPropertyName("identity")] public required string Identity { get; init; }
-        [JsonPropertyName("flags")] public required HashSet<string> Flags { get; init; }
+        [JsonPropertyName("flags")] public HashSet<string> Flags { get; init; } = new();
         [JsonPropertyName("immunity")] public uint Immunity { get; set; } = 0;
         [JsonPropertyName("command_overrides")] public Dictionary<string, bool> CommandOverrides { get; init; } = new();
     }


### PR DESCRIPTION
Quick little hotfix after the AdminManager update.

Users would define admins in `configs/admins.json` without the `flags` array and instead have flags inherited from `configs/admins_groups.json`. This PR removes the `required` keyword from the AdminData code. The only place that now requires flags is in `configs/admin_groups.json`.