### PR TITLE
Enriched SteamID

### DIFF
--- a/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountInstance.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountInstance.cs
@@ -1,0 +1,32 @@
+namespace CounterStrikeSharp.API.Modules.Entities.Constants;
+
+/// <summary>
+/// Represents the instance types for a Steam account.
+/// </summary>
+public enum SteamAccountInstance
+{
+    /// <summary>
+    /// Invalid instance.
+    /// </summary>
+    Invalid = -1,
+
+    /// <summary>
+    /// All instances.
+    /// </summary>
+    All = 0,
+
+    /// <summary>
+    /// Desktop instance.
+    /// </summary>
+    Desktop = 1,
+
+    /// <summary>
+    /// Console instance.
+    /// </summary>
+    Console = 2,
+
+    /// <summary>
+    /// Web instance.
+    /// </summary>
+    Web = 4
+}

--- a/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountType.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountType.cs
@@ -58,13 +58,13 @@ public enum SteamAccountType
     [EnumMember(Value = "c")]
     ConsoleUser,
     /// <summary>
+    /// P2P Super Seeder account type.
+    /// </summary>
+    [EnumMember(Value = " ")]
+    P2PSuperSeeder,
+    /// <summary>
     /// Anonymous user account type.
     /// </summary>
     [EnumMember(Value = "a")]
     AnonUser,
-    /// <summary>
-    /// P2P Super Seeder account type.
-    /// </summary>
-    [EnumMember(Value = " ")]
-    P2PSuperSeeder
 }

--- a/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountType.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountType.cs
@@ -1,0 +1,70 @@
+using System.Runtime.Serialization;
+
+namespace CounterStrikeSharp.API.Modules.Entities.Constants;
+
+/// <summary>
+/// Represents the types of Steam accounts.
+/// </summary>
+public enum SteamAccountType
+{
+    /// <summary>
+    /// Invalid account type.
+    /// </summary>
+    [EnumMember(Value = "I")]
+    Invalid = 0,
+    /// <summary>
+    /// Individual account type.
+    /// </summary>
+    [EnumMember(Value = "U")]
+    Individual,
+    /// <summary>
+    /// MultiSeat account type.
+    /// </summary>
+    [EnumMember(Value = "M")]
+    MultiSeat,
+    /// <summary>
+    /// Game Server account type.
+    /// </summary>
+    [EnumMember(Value = "G")]
+    GameServer,
+    /// <summary>
+    /// Anonymous Game Server account type.
+    /// </summary>
+    [EnumMember(Value = "A")]
+    AnonGameServer,
+    /// <summary>
+    /// Pending account type.
+    /// </summary>
+    [EnumMember(Value = "P")]
+    Pending,
+    /// <summary>
+    /// Content Server account type.
+    /// </summary>
+    [EnumMember(Value = "C")]
+    ContentServer,
+    /// <summary>
+    /// Clan account type.
+    /// </summary>
+    [EnumMember(Value = "g")]
+    Clan,
+    /// <summary>
+    /// Chat account type.
+    /// </summary>
+    [EnumMember(Value = "T")]
+    Chat,
+    /// <summary>
+    /// Console user account type.
+    /// </summary>
+    [EnumMember(Value = "c")]
+    ConsoleUser,
+    /// <summary>
+    /// Anonymous user account type.
+    /// </summary>
+    [EnumMember(Value = "a")]
+    AnonUser,
+    /// <summary>
+    /// P2P Super Seeder account type.
+    /// </summary>
+    [EnumMember(Value = " ")]
+    P2PSuperSeeder
+}

--- a/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountUniverse.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountUniverse.cs
@@ -6,9 +6,9 @@ namespace CounterStrikeSharp.API.Modules.Entities.Constants;
 public enum SteamAccountUniverse
 {
     /// <summary>
-    /// Invalid universe.
+    /// Individual / unspecified universe.
     /// </summary>
-    Invalid = 0,
+    Unspecified = 0,
 
     /// <summary>
     /// Public universe.

--- a/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountUniverse.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/Constants/SteamAccountUniverse.cs
@@ -1,0 +1,32 @@
+namespace CounterStrikeSharp.API.Modules.Entities.Constants;
+
+/// <summary>
+/// Represents the universe of a Steam account.
+/// </summary>
+public enum SteamAccountUniverse
+{
+    /// <summary>
+    /// Invalid universe.
+    /// </summary>
+    Invalid = 0,
+
+    /// <summary>
+    /// Public universe.
+    /// </summary>
+    Public = 1,
+
+    /// <summary>
+    /// Beta universe.
+    /// </summary>
+    Beta = 2,
+
+    /// <summary>
+    /// Internal universe.
+    /// </summary>
+    Internal = 3,
+
+    /// <summary>
+    /// Development universe.
+    /// </summary>
+    Dev = 4,
+}

--- a/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
@@ -14,14 +14,14 @@ namespace CounterStrikeSharp.API.Modules.Entities
         public static explicit operator SteamID(ulong u) => new(u);
         public static explicit operator SteamID(string s) => new(s);
 
-        static ulong ParseId(string id)
+        ulong ParseId(string id)
         {
             var parts = id.Split(':');
             if (parts.Length != 3 || !ulong.TryParse(parts[2], out var num)) throw new FormatException();
             return Base + num * 2 + (parts[1] == "1" ? 1UL : 0);
         }
 
-        static ulong ParseId3(string id)
+        ulong ParseId3(string id)
         {
             var parts = id.Replace("[", "").Replace("]", "").Split(':');
             if (parts.Length != 3 || !ulong.TryParse(parts[2], out var num)) throw new FormatException();

--- a/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
@@ -80,9 +80,9 @@ namespace CounterStrikeSharp.API.Modules.Entities
         {
             string url = string.Empty;
             if (AccountType == SteamAccountType.Individual)
-                url = "http://steamcommunity.com/profiles/" + SteamId64;
+                url = "https://steamcommunity.com/profiles/" + SteamId64;
             if (AccountType == SteamAccountType.Clan)
-                url = "http://steamcommunity.com/gid/" + SteamId64;
+                url = "https://steamcommunity.com/gid/" + SteamId64;
             return new Uri(url);
         }
 

--- a/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
@@ -59,7 +59,7 @@ namespace CounterStrikeSharp.API.Modules.Entities
 
         public bool IsValid()
         {
-            if (AccountUniverse == SteamAccountUniverse.Invalid 
+            if (AccountUniverse == SteamAccountUniverse.Unspecified 
                 || AccountType == SteamAccountType.Invalid 
                 || AccountInstance == SteamAccountInstance.Invalid)
                 return false;

--- a/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/SteamID.cs
@@ -1,4 +1,5 @@
-using System;
+using CounterStrikeSharp.API.Modules.Entities.Constants;
+using CounterStrikeSharp.API.Modules.Utils;
 
 namespace CounterStrikeSharp.API.Modules.Entities
 {
@@ -12,14 +13,15 @@ namespace CounterStrikeSharp.API.Modules.Entities
 
         public static explicit operator SteamID(ulong u) => new(u);
         public static explicit operator SteamID(string s) => new(s);
-        ulong ParseId(string id)
+
+        static ulong ParseId(string id)
         {
             var parts = id.Split(':');
             if (parts.Length != 3 || !ulong.TryParse(parts[2], out var num)) throw new FormatException();
             return Base + num * 2 + (parts[1] == "1" ? 1UL : 0);
         }
 
-        ulong ParseId3(string id)
+        static ulong ParseId3(string id)
         {
             var parts = id.Replace("[", "").Replace("]", "").Split(':');
             if (parts.Length != 3 || !ulong.TryParse(parts[2], out var num)) throw new FormatException();
@@ -34,7 +36,7 @@ namespace CounterStrikeSharp.API.Modules.Entities
 
         public string SteamId3
         {
-            get => $"[U:1:{SteamId64 - Base}]";
+            get => $"[{EnumUtils.GetEnumMemberAttributeValue(AccountType)}:{(int)AccountUniverse}:{SteamId64 - Base}]";
             set => SteamId64 = ParseId3(value);
         }
         
@@ -44,7 +46,45 @@ namespace CounterStrikeSharp.API.Modules.Entities
             set => SteamId64 = (ulong)value + Base;
         }
 
+        public int AccountId => (int)((SteamId64 >> 0) & 0xFFFFFFFF);
+
+        public SteamAccountInstance AccountInstance => 
+            (SteamAccountInstance)((SteamId64 >> 32) & 0xFFFFF);
+ 
+        public SteamAccountType AccountType => 
+            (SteamAccountType)((SteamId64 >> 52) & 0xF);
+
+        public SteamAccountUniverse AccountUniverse => 
+            (SteamAccountUniverse)((SteamId64 >> 56) & 0xF);
+
+        public bool IsValid()
+        {
+            if (AccountUniverse == SteamAccountUniverse.Invalid 
+                || AccountType == SteamAccountType.Invalid 
+                || AccountInstance == SteamAccountInstance.Invalid)
+                return false;
+            if (AccountType == SteamAccountType.Individual 
+                && (AccountId == 0 || AccountInstance != SteamAccountInstance.Desktop))
+                return false;
+            if (AccountType == SteamAccountType.Clan 
+                && (AccountId == 0 || AccountInstance != SteamAccountInstance.All))
+                return false;
+            if (AccountType == SteamAccountType.GameServer && AccountId == 0)
+                return false;
+            return true;
+        }
+
         public override string ToString() => $"[SteamID {SteamId64}, {SteamId2}, {SteamId3}]";
+
+        public Uri ToCommunityUrl()
+        {
+            string url = string.Empty;
+            if (AccountType == SteamAccountType.Individual)
+                url = "http://steamcommunity.com/profiles/" + SteamId64;
+            if (AccountType == SteamAccountType.Clan)
+                url = "http://steamcommunity.com/gid/" + SteamId64;
+            return new Uri(url);
+        }
 
         public bool Equals(SteamID? other)
         {


### PR DESCRIPTION
**Update:**
Added support for

* AccountId
* AccountInstance
* AccountType
* AccountUniverse

Which also allows for` IsValid()` check and `ToCommunityUrl()`

**Tests:**
```
[SteamID 76561197960524373, STEAM_0:1:129322, [U:1:258645]]
Valid: True
AccountId: 258645
AccountType: Individual
AccountInstance: Desktop
AccountUniverse: Public
```

```
[SteamID 0, STEAM_0:0:9185091437874642944, [I:0:18370182875749285888]]
Valid: False
AccountId: 0
AccountType: Invalid
AccountInstance: All
AccountUniverse: Invalid
```

```
[SteamID 76561197960265728, STEAM_0:0:0, [U:1:0]]
Valid: False
AccountId: 0
AccountType: Individual
AccountInstance: Desktop
AccountUniverse: Public
```

```
[SteamID 103582791429521412, STEAM_0:0:13510796734627842, [g:1:27021593469255684]]
Valid: True
AccountId: 4
AccountType: Clan
AccountInstance: All
AccountUniverse: Public
```