### PR TITLE
feat: Add entity output hooking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ SET(SOURCE_FILES
     src/core/managers/server_manager.h
     src/scripting/natives/natives_server.cpp
     libraries/nlohmann/json.hpp
-        src/scripting/natives/natives_dynamichooks.cpp
+    src/scripting/natives/natives_dynamichooks.cpp
 )
 
 

--- a/configs/addons/counterstrikesharp/gamedata/gamedata.json
+++ b/configs/addons/counterstrikesharp/gamedata/gamedata.json
@@ -164,5 +164,12 @@
       "windows": 91,
       "linux": 91
     }
+  },
+  "CEntityIOOutput_FireOutputInternal": {
+    "signatures": {
+      "library": "server",
+      "windows": "\\x48\\x8B\\xC4\\x4C\\x89\\x48\\x20\\x55\\x57\\x41\\x54\\x41\\x56",
+      "linux": "\\x55\\x48\\x89\\xE5\\x41\\x57\\x41\\x56\\x41\\x55\\x41\\x54\\x53\\x48\\x83\\xEC\\x58\\x4C\\x8B\\x6F\\x08"
+    }
   }
 }

--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -609,6 +609,30 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+        public static void HookEntityOutput(string classname, string outputname, InputArgument callback){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.Push(classname);
+			ScriptContext.GlobalScriptContext.Push(outputname);
+			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x15245242);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
+        public static void UnhookEntityOutput(string classname, string outputname, InputArgument callback){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.Push(classname);
+			ScriptContext.GlobalScriptContext.Push(outputname);
+			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x87DBD139);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
         public static void HookEvent(string name, InputArgument callback, bool ispost){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
@@ -1230,34 +1254,5 @@ namespace CounterStrikeSharp.API.Core
 			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
 			}
 		}
-
-
-        public static void HookEntityOutput(string classname, string outputName, InputArgument callback)
-        {
-            lock (ScriptContext.GlobalScriptContext.Lock)
-            {
-                ScriptContext.GlobalScriptContext.Reset();
-                ScriptContext.GlobalScriptContext.Push(classname);
-                ScriptContext.GlobalScriptContext.Push(outputName);
-                ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-                ScriptContext.GlobalScriptContext.SetIdentifier(0x15245242);
-                ScriptContext.GlobalScriptContext.Invoke();
-                ScriptContext.GlobalScriptContext.CheckErrors();
-            }
-        }
-
-        public static void UnhookEntityOutput(string classname, string outputName, InputArgument callback)
-        {
-            lock (ScriptContext.GlobalScriptContext.Lock)
-            {
-                ScriptContext.GlobalScriptContext.Reset();
-                ScriptContext.GlobalScriptContext.Push(classname);
-                ScriptContext.GlobalScriptContext.Push(outputName);
-                ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-                ScriptContext.GlobalScriptContext.SetIdentifier(0x87dbd139);
-                ScriptContext.GlobalScriptContext.Invoke();
-                ScriptContext.GlobalScriptContext.CheckErrors();
-            }
-        }
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -1230,5 +1230,34 @@ namespace CounterStrikeSharp.API.Core
 			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
 			}
 		}
+
+
+        public static void HookEntityOutput(string classname, string outputName, InputArgument callback)
+        {
+            lock (ScriptContext.GlobalScriptContext.Lock)
+            {
+                ScriptContext.GlobalScriptContext.Reset();
+                ScriptContext.GlobalScriptContext.Push(classname);
+                ScriptContext.GlobalScriptContext.Push(outputName);
+                ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
+                ScriptContext.GlobalScriptContext.SetIdentifier(0x15245242);
+                ScriptContext.GlobalScriptContext.Invoke();
+                ScriptContext.GlobalScriptContext.CheckErrors();
+            }
+        }
+
+        public static void UnhookEntityOutput(string classname, string outputName, InputArgument callback)
+        {
+            lock (ScriptContext.GlobalScriptContext.Lock)
+            {
+                ScriptContext.GlobalScriptContext.Reset();
+                ScriptContext.GlobalScriptContext.Push(classname);
+                ScriptContext.GlobalScriptContext.Push(outputName);
+                ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
+                ScriptContext.GlobalScriptContext.SetIdentifier(0x87dbd139);
+                ScriptContext.GlobalScriptContext.Invoke();
+                ScriptContext.GlobalScriptContext.CheckErrors();
+            }
+        }
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Attributes/Registration/EntityOutputHookAttribute.cs
+++ b/managed/CounterStrikeSharp.API/Core/Attributes/Registration/EntityOutputHookAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace CounterStrikeSharp.API.Core.Attributes.Registration;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class EntityOutputHookAttribute : Attribute
+{
+    public string Classname { get; }
+    public string OutputName { get; }
+
+    public EntityOutputHookAttribute(string classname, string outputName)
+    {
+        Classname = classname;
+        OutputName = outputName;
+    }
+}

--- a/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
@@ -486,13 +486,7 @@ namespace CounterStrikeSharp.API.Core
             // if the entity instance is the same.
             EntityIO.EntityOutputHandler internalHandler = (string name, CEntityInstance activator, CEntityInstance caller, float delay) =>
             {
-                // TODO: this needs to be changed when equality check between 'CEntityInstance' instances is fixed
-                // currently this is what's happening:
-                // caller.EntityHandle.Raw == entityInstance.EntityHandle.Raw results true
-                // caller == entityInstance results false
-                // caller.Equals(entityInstance) results false
-                // we shouldn't check the reference of the instance because it is not guaranteed to be the same even if its the same entity.
-                if (caller.EntityHandle.Raw == entityInstance.EntityHandle.Raw)
+                if (caller == entityInstance)
                 {
                     handler(name, activator, caller, delay);
                 }

--- a/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
@@ -359,6 +359,7 @@ namespace CounterStrikeSharp.API.Core
         {
             this.RegisterAttributeHandlers(instance);
             this.RegisterConsoleCommandAttributeHandlers(instance);
+            this.RegisterEntityOutputAttributeHandlers(instance);
         }
 
         public void InitializeConfig(object instance, Type pluginType)
@@ -431,6 +432,23 @@ namespace CounterStrikeSharp.API.Core
                 {
                     AddCommand(commandInfo.Command, commandInfo.Description,
                         eventHandler.CreateDelegate<CommandInfo.CommandCallback>(instance));
+                }
+            }
+        }
+
+        public void RegisterEntityOutputAttributeHandlers(object instance)
+        {
+            var handlers = instance.GetType()
+                .GetMethods()
+                .Where(method => method.GetCustomAttributes<EntityOutputHookAttribute>().Any())
+                .ToArray();
+
+            foreach (var handler in handlers)
+            {
+                var attributes = handler.GetCustomAttributes<EntityOutputHookAttribute>();
+                foreach (var outputInfo in attributes)
+                {
+                    HookEntityOutput(outputInfo.Classname, outputInfo.OutputName, handler.CreateDelegate<EntityOutputHandler>(instance));
                 }
             }
         }

--- a/managed/CounterStrikeSharp.API/Modules/Entities/EntityIO.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Entities/EntityIO.cs
@@ -1,0 +1,39 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
+ */
+
+namespace CounterStrikeSharp.API.Modules.Entities
+{
+    public class EntityIO
+    {
+        public delegate void EntityOutputHandler(string name, CEntityInstance activator, CEntityInstance caller, float delay);
+
+        internal class EntityOutputCallback
+        {
+            public string Classname;
+
+            public string Output;
+
+            public EntityOutputHandler Handler;
+
+            public EntityOutputCallback(string classname, string output, EntityOutputHandler handler)
+            {
+                Classname = classname;
+                Output = output;
+                Handler = handler;
+            }
+        }
+    }
+}

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -553,5 +553,11 @@ namespace TestPlugin
 
             return HookResult.Continue;
         }
+
+        [EntityOutputHook("weapon_knife", "OnPlayerPickup")]
+        public void OnKnifePickup(string name, CEntityInstance activator, CEntityInstance caller, float delay)
+        {
+            Logger.LogInformation("[EntityOutputHook Attribute] weapon_knife called OnPlayerPickup ({name}, {activator}, {caller}, {delay})", name, activator.DesignerName, caller.DesignerName, delay);
+        }
     }
 }

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -93,6 +93,7 @@ namespace TestPlugin
             SetupListeners();
             SetupCommands();
             SetupMenus();
+            SetupEntityOutputHooks();
 
             // ValveInterface provides pointers to loaded modules via Interface Name exposed from the engine (e.g. Source2Server001)
             var server = ValveInterface.Server;
@@ -403,6 +404,14 @@ namespace TestPlugin
                     info.ArgString);
 
                 return HookResult.Continue;
+            });
+        }
+
+        private void SetupEntityOutputHooks()
+        {
+            HookEntityOutput("weapon_knife", "OnPlayerPickup", (string name, CEntityInstance activator, CEntityInstance caller, float delay) =>
+            {
+                Logger.LogInformation("weapon_knife called OnPlayerPickup ({name}, {activator}, {caller}, {delay})", name, activator.DesignerName, caller.DesignerName, delay);
             });
         }
 

--- a/src/core/managers/entity_manager.h
+++ b/src/core/managers/entity_manager.h
@@ -24,8 +24,15 @@
 #include "scripting/script_engine.h"
 #include "entitysystem.h"
 
+// variant.h depends on ivscript.h, lets not include the whole thing
+DECLARE_POINTER_HANDLE(HSCRIPT);
+
+#include <variant.h>
+
 namespace counterstrikesharp {
 class ScriptCallback;
+
+typedef std::pair<std::string, std::string> OutputKey_t;
 
 class CEntityListener : public IEntityListener {
     void OnEntitySpawned(CEntityInstance *pEntity) override;
@@ -41,12 +48,69 @@ public:
     ~EntityManager();
     void OnAllInitialized() override;
     void OnShutdown() override;
+    void HookEntityOutput(const char* szClassname, const char* szOutput, CallbackT fnCallback);
+    void UnhookEntityOutput(const char* szClassname, const char* szOutput, CallbackT fnCallback);
     CEntityListener entityListener;
+    std::map<OutputKey_t, counterstrikesharp::ScriptCallback*> m_pHookMap;
 private:
     ScriptCallback *on_entity_spawned_callback;
     ScriptCallback *on_entity_created_callback;
     ScriptCallback *on_entity_deleted_callback;
     ScriptCallback *on_entity_parent_changed_callback;
 };
+
+
+enum EntityIOTargetType_t
+{
+    ENTITY_IO_TARGET_INVALID = 0xFFFFFFFF,
+    ENTITY_IO_TARGET_CLASSNAME = 0x0,
+    ENTITY_IO_TARGET_CLASSNAME_DERIVES_FROM = 0x1,
+    ENTITY_IO_TARGET_ENTITYNAME = 0x2,
+    ENTITY_IO_TARGET_CONTAINS_COMPONENT = 0x3,
+    ENTITY_IO_TARGET_SPECIAL_ACTIVATOR = 0x4,
+    ENTITY_IO_TARGET_SPECIAL_CALLER = 0x5,
+    ENTITY_IO_TARGET_EHANDLE = 0x6,
+    ENTITY_IO_TARGET_ENTITYNAME_OR_CLASSNAME = 0x7,
+};
+
+struct EntityIOConnectionDesc_t
+{
+    string_t m_targetDesc;
+    string_t m_targetInput;
+    string_t m_valueOverride;
+    CEntityHandle m_hTarget;
+    EntityIOTargetType_t m_nTargetType;
+    int32 m_nTimesToFire;
+    float m_flDelay;
+};
+
+struct EntityIOConnection_t : EntityIOConnectionDesc_t
+{
+    bool m_bMarkedForRemoval;
+    EntityIOConnection_t* m_pNext;
+};
+
+struct EntityIOOutputDesc_t
+{
+    const char* m_pName;
+    uint32 m_nFlags;
+    uint32 m_nOutputOffset;
+};
+
+class CEntityIOOutput
+{
+  public:
+    void* vtable;
+    EntityIOConnection_t* m_pConnections;
+    EntityIOOutputDesc_t* m_pDesc;
+};
+
+typedef void (*FireOutputInternal)(CEntityIOOutput* const, CEntityInstance*, CEntityInstance*,
+                                   const CVariant* const, float);
+
+static void DetourFireOutputInternal(CEntityIOOutput* const pThis, CEntityInstance* pActivator,
+                                     CEntityInstance* pCaller, const CVariant* const value, float flDelay);
+
+static FireOutputInternal m_pFireOutputInternal = nullptr;
 
 }  // namespace counterstrikesharp

--- a/src/scripting/natives/natives_entities.cpp
+++ b/src/scripting/natives/natives_entities.cpp
@@ -22,6 +22,7 @@
 #include "core/memory.h"
 #include "core/log.h"
 #include "core/managers/player_manager.h"
+#include "core/managers/entity_manager.h"
 
 #include <public/entity2/entitysystem.h>
 
@@ -132,6 +133,22 @@ unsigned long GetPlayerAuthorizedSteamID(ScriptContext& script_context) {
     return pSteamId->ConvertToUint64();
 }
 
+void HookEntityOutput(ScriptContext& script_context)
+{
+    auto szClassname = script_context.GetArgument<const char*>(0);
+    auto szOutput = script_context.GetArgument<const char*>(1);
+    auto callback = script_context.GetArgument<CallbackT>(2);
+    globals::entityManager.HookEntityOutput(szClassname, szOutput, callback);
+}
+
+void UnhookEntityOutput(ScriptContext& script_context)
+{
+    auto szClassname = script_context.GetArgument<const char*>(0);
+    auto szOutput = script_context.GetArgument<const char*>(1);
+    auto callback = script_context.GetArgument<CallbackT>(2);
+    globals::entityManager.UnhookEntityOutput(szClassname, szOutput, callback);
+}
+
 REGISTER_NATIVES(entities, {
     ScriptEngine::RegisterNativeHandler("GET_ENTITY_FROM_INDEX", GetEntityFromIndex);
     ScriptEngine::RegisterNativeHandler("GET_USERID_FROM_INDEX", GetUserIdFromIndex);
@@ -145,5 +162,7 @@ REGISTER_NATIVES(entities, {
     ScriptEngine::RegisterNativeHandler("PRINT_TO_CONSOLE", PrintToConsole);
     ScriptEngine::RegisterNativeHandler("GET_FIRST_ACTIVE_ENTITY", GetFirstActiveEntity);
     ScriptEngine::RegisterNativeHandler("GET_PLAYER_AUTHORIZED_STEAMID", GetPlayerAuthorizedSteamID);
+    ScriptEngine::RegisterNativeHandler("HOOK_ENTITY_OUTPUT", HookEntityOutput);
+    ScriptEngine::RegisterNativeHandler("UNHOOK_ENTITY_OUTPUT", UnhookEntityOutput);
 })
 }  // namespace counterstrikesharp

--- a/src/scripting/natives/natives_entities.yaml
+++ b/src/scripting/natives/natives_entities.yaml
@@ -9,3 +9,5 @@ IS_REF_VALID_ENTITY: entityRef:uint -> bool
 PRINT_TO_CONSOLE: index:int, message:string -> void
 GET_FIRST_ACTIVE_ENTITY: -> pointer
 GET_PLAYER_AUTHORIZED_STEAMID: slot:int -> uint64
+HOOK_ENTITY_OUTPUT: classname:string, outputName:string, callback:func -> void
+UNHOOK_ENTITY_OUTPUT: classname:string, outputName:string, callback:func -> void


### PR DESCRIPTION
This pull requests implements the ability to hook entity outputs for a given classname or entity.

# Examples

## HookEntityOutput

```c#
public override void Load(bool hotReload)
{
    HookEntityOutput("weapon_knife", "OnPlayerPickup", (string name, CEntityInstance activator, CEntityInstance caller, float delay) =>
    {
        Logger.LogInformation("weapon_knife called OnPlayerPickup ({name}, {activator}, {caller}, {delay})", name, activator.DesignerName, caller.DesignerName, delay);
    });
}
```

## EntityOutputHook Attribute

```c#
[EntityOutputHook("weapon_knife", "OnPlayerPickup")]
public void OnKnifePickup(string name, CEntityInstance activator, CEntityInstance caller, float delay)
{
    Logger.LogInformation("[EntityOutputHook Attribute] weapon_knife called OnPlayerPickup ({name}, {activator}, {caller}, {delay})", name, activator.DesignerName, caller.DesignerName, delay);
}
```

## Hook single entity

```c#
CBaseDoor? door = Utilities.FindAllEntitiesByDesignerName<CBaseDoor>("prop_door_rotating").FirstOrDefault();

if (door)
    HookSingleEntityOutput(door, "OnOpen", OnOpen);

public void OnOpen(string name, CEntityInstance activator, CEntityInstance caller, float delay)
{
    Console.WriteLine($"{activator.DesignerName} called {name}");
    
    // fire only once
    UnhookSingleEntityOutput(caller, "OnOpen", OnOpen);
}
```