### PR TITLE
Changed the command accessibility for some built-in administrator commands

### DIFF
--- a/examples/WithCommands/WithCommandsPlugin.cs
+++ b/examples/WithCommands/WithCommandsPlugin.cs
@@ -37,7 +37,7 @@ public class WithCommandsPlugin : BasePlugin
     [ConsoleCommand("css_hello", "Responds to the caller with \"pong\"")]
     // The `CommandHelper` attribute can be used to provide additional information about the command.
     [CommandHelper(minArgs: 1, usage: "[name]", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
-    [RequiresPermissions("@css/cvar")]
+    [RequiresPermissionsOr("@css/cvar", "@css/root")]
     public void OnHelloCommand(CCSPlayerController? player, CommandInfo commandInfo)
     {
         // The first argument is the command name, in this case "css_hello".
@@ -52,7 +52,7 @@ public class WithCommandsPlugin : BasePlugin
     
     // Permissions can be added to commands using the `RequiresPermissions` attribute.
     // See the admin documentation for more information on permissions.
-    [RequiresPermissions("@css/kick")]
+    [RequiresPermissionsOr("@css/kick", "@css/root")]
     [CommandHelper(minArgs: 1, usage: "[id]", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
     public void OnSpecialCommand(CCSPlayerController? player, CommandInfo commandInfo)
     {

--- a/managed/CounterStrikeSharp.API/Core/Application.cs
+++ b/managed/CounterStrikeSharp.API/Core/Application.cs
@@ -90,7 +90,7 @@ namespace CounterStrikeSharp.API.Core
             RegisterPluginCommands();
         }
 
-        [RequiresPermissions("@css/generic")]
+        [RequiresPermissionsOr("@css/generic", "@css/root")]
         [CommandHelper(whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
         private void OnCSSCommand(CCSPlayerController? caller, CommandInfo info)
         {
@@ -104,7 +104,7 @@ namespace CounterStrikeSharp.API.Core
             return;
         }
 
-        [RequiresPermissions("@css/generic")]
+        [RequiresPermissionsOr("@css/generic", "@css/root")]
         [CommandHelper(minArgs: 1,
             usage: "[option]\n" +
                    "  list - List all plugins currently loaded.\n" +

--- a/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
+++ b/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
@@ -104,7 +104,7 @@ namespace CounterStrikeSharp.API.Core
             _coreConfigPath = Path.Join(scriptHostConfiguration.ConfigsPath, "core.json");
         }
 
-        [RequiresPermissions("@css/config")]
+        [RequiresPermissionsOr("@css/config", "@css/root")]
         [CommandHelper(whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
         private void ReloadCoreConfigCommand(CCSPlayerController? player, CommandInfo command)
         {


### PR DESCRIPTION
Changed the administrator permission flags required in order to use some of the built-in commands in order to allow users with the root flag access to also be able to use the built-in commands explicitly available to users with the cvar, generic and config access flags. To make it align with the documentation https://docs.cssharp.dev/admin-framework/defining-admins/ in which it is stated that root access users have all other flags enabled, albeit seemingly root access users couldn't use the css_plugins command.