### PR TITLE
Prevent calling natives on non-main thread

### DIFF
--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -78,6 +78,7 @@ ChatManager chatManager;
 ServerManager serverManager;
 
 GetLegacyGameEventListener_t* GetLegacyGameEventListener = nullptr;
+std::thread::id gameThreadId;
 
 void Initialize()
 {

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -107,6 +107,7 @@ extern CGameConfig* gameConfig;
 typedef IGameEventListener2 *GetLegacyGameEventListener_t(CPlayerSlot slot);
 
 extern GetLegacyGameEventListener_t* GetLegacyGameEventListener;
+extern std::thread::id gameThreadId;
 
 void Initialize();
 // Should only be called within the active game loop (i e map should be loaded

--- a/src/mm_plugin.cpp
+++ b/src/mm_plugin.cpp
@@ -41,6 +41,15 @@ DLL_EXPORT void InvokeNative(counterstrikesharp::fxNativeContext& context)
     if (context.nativeIdentifier == 0)
         return;
 
+    if (counterstrikesharp::globals::gameThreadId != std::this_thread::get_id())
+    {
+        counterstrikesharp::ScriptContextRaw scriptContext(context);
+        scriptContext.ThrowNativeError("Invoked on a non-main thread");
+
+        CSSHARP_CORE_CRITICAL("Native {:x} was invoked on a non-main thread", context.nativeIdentifier);
+        return;
+    }
+
     counterstrikesharp::ScriptEngine::InvokeNative(context);
 }
 
@@ -67,6 +76,7 @@ bool CounterStrikeSharpMMPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, s
 {
     PLUGIN_SAVEVARS();
     globals::ismm = ismm;
+    globals::gameThreadId = std::this_thread::get_id();
 
     Log::Init();
 


### PR DESCRIPTION
Developers could accidentally call natives on another thread which could be a real hell to debug. This pull requests add a check to InvokeNative to make sure that the current thread id matches the server thread id, otherwise it will throw an exception to managed.