### PR TITLE
feat: defers calls to `HookEvent` until after game loop mode init

### DIFF
--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -212,6 +212,13 @@ namespace TestPlugin
 
                 return HookResult.Continue;
             }, HookMode.Pre);
+            
+            RegisterEventHandler<EventGrenadeBounce>((@event, info) =>
+            {
+                Logger.LogInformation("Player {Player} grenade bounce", @event.Userid.PlayerName);
+
+                return HookResult.Continue;
+            }, HookMode.Pre);
             RegisterEventHandler<EventPlayerSpawn>((@event, info) =>
             {
                 if (!@event.Userid.IsValid) return 0;

--- a/src/core/global_listener.h
+++ b/src/core/global_listener.h
@@ -45,6 +45,7 @@ public:
     virtual void OnStartup() {}
     virtual void OnShutdown() {}
     virtual void OnAllInitialized() {}
+    virtual void OnGameLoopInitialized() {}
     virtual void OnAllInitialized_Post() {}
     virtual void OnLevelChange(const char *mapName) {}
     virtual void OnLevelEnd() {}

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -43,6 +43,7 @@ IServerPluginHelpers* helpers = nullptr;
 IUniformRandomStream* randomStream = nullptr;
 IEngineTrace* engineTrace = nullptr;
 IEngineSound* engineSound = nullptr;
+IEngineServiceMgr* engineServiceManager = nullptr;
 INetworkStringTableContainer* netStringTables = nullptr;
 CGlobalVars* globalVars = nullptr;
 IFileSystem* fileSystem = nullptr;
@@ -77,6 +78,7 @@ EntityManager entityManager;
 ChatManager chatManager;
 ServerManager serverManager;
 
+bool gameLoopInitialized = false;
 GetLegacyGameEventListener_t* GetLegacyGameEventListener = nullptr;
 std::thread::id gameThreadId;
 

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -20,6 +20,7 @@ class IServerPluginHelpers;
 class IUniformRandomStream;
 class IEngineTrace;
 class IEngineSound;
+class IEngineServiceMgr;
 class INetworkStringTableContainer;
 class CGlobalVars;
 class IFileSystem;
@@ -65,6 +66,7 @@ extern IServerPluginHelpers *helpers;
 extern IUniformRandomStream *randomStream;
 extern IEngineTrace *engineTrace;
 extern IEngineSound *engineSound;
+extern IEngineServiceMgr *engineServiceManager;
 extern INetworkStringTableContainer *netStringTables;
 extern CGlobalVars *globalVars;
 extern IFileSystem *fileSystem;
@@ -108,6 +110,7 @@ extern CGameConfig* gameConfig;
 
 typedef IGameEventListener2 *GetLegacyGameEventListener_t(CPlayerSlot slot);
 
+extern bool gameLoopInitialized;
 extern GetLegacyGameEventListener_t* GetLegacyGameEventListener;
 extern std::thread::id gameThreadId;
 

--- a/src/core/managers/event_manager.h
+++ b/src/core/managers/event_manager.h
@@ -67,6 +67,12 @@ struct EventOverride {
   bool m_bDontBroadcast;
 };
 
+struct PendingEventHook {
+    std::string m_Name;
+    counterstrikesharp::CallbackT m_fnCallback;
+    bool m_bPost;
+};
+
 namespace counterstrikesharp {
 
 class EventManager : public IGameEventListener2, public GlobalClass
@@ -79,6 +85,7 @@ class EventManager : public IGameEventListener2, public GlobalClass
     void OnShutdown() override;
     void OnAllInitialized() override;
     void OnStartup() override;
+    void OnGameLoopInitialized() override;
 
     // IGameEventListener2
     void FireGameEvent(IGameEvent* pEvent) override;
@@ -94,6 +101,7 @@ class EventManager : public IGameEventListener2, public GlobalClass
 
     std::stack<EventHook *> m_EventStack;
     std::stack<IGameEvent *> m_EventCopies;
+    std::stack<PendingEventHook> m_PendingHooks;
 };
 
 } // namespace counterstrikesharp

--- a/src/mm_plugin.cpp
+++ b/src/mm_plugin.cpp
@@ -64,6 +64,8 @@ namespace counterstrikesharp {
 SH_DECL_HOOK3_void(IServerGameDLL, GameFrame, SH_NOATTRIB, 0, bool, bool, bool);
 SH_DECL_HOOK3_void(INetworkServerService, StartupServer, SH_NOATTRIB, 0,
                    const GameSessionConfiguration_t&, ISource2WorldSession*, const char*);
+SH_DECL_HOOK3_void(IEngineServiceMgr, RegisterLoopMode, SH_NOATTRIB, 0, const char *, ILoopModeFactory *, void **);
+SH_DECL_HOOK1(IEngineServiceMgr, FindService, SH_NOATTRIB, 0, IEngineService*, const char*);
 
 CounterStrikeSharpMMPlugin gPlugin;
 
@@ -95,6 +97,8 @@ bool CounterStrikeSharpMMPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, s
                     NETWORKSERVERSERVICE_INTERFACE_VERSION);
     GET_V_IFACE_ANY(GetEngineFactory, globals::gameEventSystem, IGameEventSystem,
                     GAMEEVENTSYSTEM_INTERFACE_VERSION);
+    GET_V_IFACE_ANY(GetEngineFactory, globals::engineServiceManager, IEngineServiceMgr,
+                    ENGINESERVICEMGR_INTERFACE_VERSION);
 
     auto coreconfig_path = std::string(utils::ConfigsDirectory() + "/core");
     globals::coreConfig = new CCoreConfig(coreconfig_path);
@@ -129,6 +133,8 @@ bool CounterStrikeSharpMMPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, s
                         &CounterStrikeSharpMMPlugin::Hook_GameFrame, true);
     SH_ADD_HOOK_MEMFUNC(INetworkServerService, StartupServer, globals::networkServerService, this,
                         &CounterStrikeSharpMMPlugin::Hook_StartupServer, true);
+    SH_ADD_HOOK_MEMFUNC(IEngineServiceMgr, RegisterLoopMode, globals::engineServiceManager, this, &CounterStrikeSharpMMPlugin::Hook_RegisterLoopMode, false);
+    SH_ADD_HOOK_MEMFUNC(IEngineServiceMgr, FindService, globals::engineServiceManager, this, &CounterStrikeSharpMMPlugin::Hook_FindService, true);
 
     if (!globals::dotnetManager.Initialize()) {
         CSSHARP_CORE_ERROR("Failed to initialize .NET runtime");
@@ -212,6 +218,23 @@ void CounterStrikeSharpMMPlugin::OnLevelInit(char const* pMapName, char const* p
                                              bool loadGame, bool background)
 {
     CSSHARP_CORE_TRACE("name={0},mapname={1}", "LevelInit", pMapName);
+}
+
+void CounterStrikeSharpMMPlugin::Hook_RegisterLoopMode(const char *pszLoopModeName, ILoopModeFactory *pLoopModeFactory, void **ppGlobalPointer)
+{
+    if (strcmp(pszLoopModeName, "game") == 0)
+    {
+        if (!globals::gameLoopInitialized) globals::gameLoopInitialized = true;
+
+        CALL_GLOBAL_LISTENER(OnGameLoopInitialized());
+    }
+}
+
+IEngineService* CounterStrikeSharpMMPlugin::Hook_FindService(const char* serviceName)
+{
+    IEngineService *pService = META_RESULT_ORIG_RET(IEngineService *);
+
+    return pService;
 }
 
 void CounterStrikeSharpMMPlugin::OnLevelShutdown() {}

--- a/src/mm_plugin.h
+++ b/src/mm_plugin.h
@@ -49,6 +49,9 @@ public:  // hooks
                             const char *);
     void AddTaskForNextFrame(std::function<void()> &&task);
 
+    void Hook_RegisterLoopMode(const char* pszLoopModeName, ILoopModeFactory *pLoopModeFactory, void **ppGlobalPointer);
+    IEngineService* Hook_FindService(const char* serviceName);
+
 public:
     const char *GetAuthor() override;
     const char *GetName() override;


### PR DESCRIPTION
The `Load` method of plugins (and CS#) is before game loop starts, which I believe includes other services. You can see in the console of startup that the events file is only loaded *after* CS#. This change defers all calls to `HookEvent` in a queue and registers them once the game loop mode is registered. Fixes #140

![image](https://github.com/roflmuffin/CounterStrikeSharp/assets/4160975/d72bf856-e89a-4640-8451-519cdebbd93a)

