### PR TITLE
Docs: Using DOTNET_SYSTEM_GLOBALIZATION_INVARIANT is no longer valid.

### DIFF
--- a/docfx/docs/guides/getting-started.md
+++ b/docfx/docs/guides/getting-started.md
@@ -17,7 +17,7 @@ Download the latest release of CounterStrikeSharp from <a href="https://github.c
 
 > [!CAUTION]
 > If this is your first time installing, you will need to download the `with-runtime` version. This includes a copy of the .NET runtime, which is required to run the plugin.
-> Depending on the os you might also either need to install `libicu` / `icu-libs` / `libicu-dev` using your package manager for .NET to run or setting `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true` in your servers environment variables. You can find more infos about that <a href="https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode" target="_blank">here</a> 
+> Depending on the os you might also either need to install `libicu` / `icu-libs` / `libicu-dev` using your package manager for .NET to run. You can find more infos about that <a href="https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode" target="_blank">here</a> 
 > 
 > Subsequent upgrades will not require the runtime, unless a version bump of the .NET runtime is required (i.e. from 7.0.x to 8.0.x). We will inform you when this occurs.
 

--- a/docfx/docs/guides/getting-started.md
+++ b/docfx/docs/guides/getting-started.md
@@ -17,7 +17,7 @@ Download the latest release of CounterStrikeSharp from <a href="https://github.c
 
 > [!CAUTION]
 > If this is your first time installing, you will need to download the `with-runtime` version. This includes a copy of the .NET runtime, which is required to run the plugin.
-> Depending on the os you might also either need to install `libicu` / `icu-libs` / `libicu-dev` using your package manager for .NET to run. You can find more infos about that <a href="https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#enabling-the-invariant-mode" target="_blank">here</a> 
+> Depending on the os you might also either need to install `libicu` / `icu-libs` / `libicu-dev` using your package manager for .NET to run.
 > 
 > Subsequent upgrades will not require the runtime, unless a version bump of the .NET runtime is required (i.e. from 7.0.x to 8.0.x). We will inform you when this occurs.
 


### PR DESCRIPTION
Since CSS now supports translations, icu lib is required.