### PR TITLE
Added a parameter for people to optionally remove the entity when calling RemoveItemByDesignerName

### DIFF
--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -90,7 +90,7 @@ namespace CounterStrikeSharp.API
                 item = weapon;
             }
             
-            if(item != null && item.Value != null)
+            if (item != null && item.Value != null)
             {
                 player.PlayerPawn.Value.RemovePlayerItem(item.Value);
 

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -75,7 +75,12 @@ namespace CounterStrikeSharp.API
             return new Target(pattern).GetTarget(player);
         }
 
-        public static bool RemoveItemByDesignerName(this CCSPlayerController player, string designerName, bool shouldRemoveEntity = false)
+        public static bool RemoveItemByDesignerName(this CCSPlayerController player, string designerName)
+        {
+            return RemoveItemByDesignerName(player, designerName, false);
+        }
+
+        public static bool RemoveItemByDesignerName(this CCSPlayerController player, string designerName, bool shouldRemoveEntity)
         {
             CHandle<CBasePlayerWeapon>? item = null;
             if (player.PlayerPawn.Value == null || player.PlayerPawn.Value.WeaponServices == null) return false;

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -75,7 +75,7 @@ namespace CounterStrikeSharp.API
             return new Target(pattern).GetTarget(player);
         }
 
-        public static bool RemoveItemByDesignerName(this CCSPlayerController player, string designerName)
+        public static bool RemoveItemByDesignerName(this CCSPlayerController player, string designerName, bool shouldRemoveEntity = false)
         {
             CHandle<CBasePlayerWeapon>? item = null;
             if (player.PlayerPawn.Value == null || player.PlayerPawn.Value.WeaponServices == null) return false;
@@ -93,6 +93,12 @@ namespace CounterStrikeSharp.API
             if(item != null && item.Value != null)
             {
                 player.PlayerPawn.Value.RemovePlayerItem(item.Value);
+
+                if (shouldRemoveEntity)
+                {
+                    item.Value.Remove();
+                }
+
                 return true;
             }
             


### PR DESCRIPTION
I was caught out by doing `player.RemoveItemByDesignerName("weapon_c4");`, it removed the item from the players inventory but didn't remove the entity.

Here's a PR to allow people to specify whether or not they would like to also remove the entity.

New usage:
`player.RemoveItemByDesignerName("weapon_c4", true);`