### PR TITLE
Shared Plugin Api: register and call functions between plugins.

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
@@ -50,9 +50,9 @@ namespace CounterStrikeSharp.API.Core
 
         public abstract string ModuleName { get; }
         public abstract string ModuleVersion { get; }
-        
+
         public virtual string ModuleAuthor { get; }
-        
+
         public virtual string ModuleDescription { get; }
 
         public string ModulePath { get; set; }
@@ -61,7 +61,7 @@ namespace CounterStrikeSharp.API.Core
         public ILogger Logger { get; set; }
 
         public IStringLocalizer Localizer { get; set; }
-        
+
         public virtual void Load(bool hotReload)
         {
         }
@@ -110,7 +110,7 @@ namespace CounterStrikeSharp.API.Core
 
         public readonly Dictionary<Delegate, CallbackSubscriber> CommandHandlers =
             new Dictionary<Delegate, CallbackSubscriber>();
-        
+
         public readonly Dictionary<Delegate, CallbackSubscriber> CommandListeners =
             new Dictionary<Delegate, CallbackSubscriber>();
 
@@ -127,7 +127,7 @@ namespace CounterStrikeSharp.API.Core
             new Dictionary<Delegate, EntityIO.EntityOutputCallback>();
 
         public readonly List<Timer> Timers = new List<Timer>();
-        
+
         public delegate HookResult GameEventHandler<T>(T @event, GameEventInfo info) where T : GameEvent;
 
         private void RegisterEventHandlerInternal<T>(string name, GameEventHandler<T> handler, bool post)
@@ -174,14 +174,14 @@ namespace CounterStrikeSharp.API.Core
             {
                 var caller = (i != -1) ? new CCSPlayerController(NativeAPI.GetEntityFromIndex(i + 1)) : null;
                 var command = new CommandInfo(ptr, caller);
-                
+
                 using var temporaryCulture = new WithTemporaryCulture(caller.GetLanguage());
 
                 var methodInfo = handler?.GetMethodInfo();
 
                 // We do not need to do permission checks on commands executed from the server console.
                 // The server will always be allowed to execute commands (unless marked as client only like above)
-                if (caller != null) 
+                if (caller != null)
                 {
                     // Do not execute command if we do not have the correct permissions.
                     var adminData = AdminManager.GetPlayerAdminData(caller!.AuthorizedSteamID);
@@ -541,6 +541,11 @@ namespace CounterStrikeSharp.API.Core
             EntitySingleOutputHooks.Remove(handler);
         }
 
+        public void RegisterSharedApi(string name, Delegate func)
+        {
+            SharedPluginApi.RegisterFunction(this, name, func);
+        }
+
         public void Dispose()
         {
             Dispose(true);
@@ -551,6 +556,8 @@ namespace CounterStrikeSharp.API.Core
             if (_disposed) return;
             if (!disposing) return;
 
+            SharedPluginApi.UnregisterPlugins(this);
+
             foreach (var subscriber in Handlers.Values)
             {
                 subscriber.Dispose();
@@ -560,7 +567,7 @@ namespace CounterStrikeSharp.API.Core
             {
                 subscriber.Dispose();
             }
-            
+
             foreach (var subscriber in CommandListeners.Values)
             {
                 subscriber.Dispose();

--- a/managed/CounterStrikeSharp.API/Core/SharedPluginApi.cs
+++ b/managed/CounterStrikeSharp.API/Core/SharedPluginApi.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CounterStrikeSharp.API.Core
+{
+    public static class SharedPluginApi
+    {
+        private static readonly List<ApiFuncRegister> allFuncs = new();
+        
+        internal static void RegisterFunction(IPlugin plugin, string name, Delegate func)
+        {
+            var v = new ApiFuncRegister(plugin, name, func);
+            allFuncs.Add(v);
+        }
+
+        internal static void UnregisterPlugins(IPlugin plugin)
+        {
+            allFuncs.RemoveAll(x => x.Plugin.Equals(plugin));
+        }
+
+        public static object? Call(string moduleName, string funcName, params object?[] values)
+        {
+            var pluginFound = false;
+            var v = allFuncs.LastOrDefault(x =>
+            {
+                if (!moduleName.Equals(x.Plugin.ModuleName)) { return false; }
+                pluginFound = true;
+                return funcName.Equals(x.Name);
+            });
+            if (v == null)
+            {
+                if (pluginFound)
+                {
+                    throw new Exception($"cannot find '{funcName}' shared api in '{moduleName}'");
+                }
+                throw new Exception($"cannot find plugin called '{moduleName}'");
+            }
+            return v.Function.DynamicInvoke(values);
+        }
+
+        private class ApiFuncRegister
+        {
+            public ApiFuncRegister(IPlugin plugin, string name, Delegate func)
+            {
+                this.Plugin = plugin;
+                this.Name = name;
+                this.Function = func;
+            }
+
+            public IPlugin Plugin { get; }
+            public string Name { get; }
+            public Delegate Function { get; }
+        }
+
+    }
+
+}

--- a/managed/CounterStrikeSharp.API/Core/SharedPluginApi.cs
+++ b/managed/CounterStrikeSharp.API/Core/SharedPluginApi.cs
@@ -9,7 +9,7 @@ namespace CounterStrikeSharp.API.Core
     public static class SharedPluginApi
     {
         private static readonly List<ApiFuncRegister> allFuncs = new();
-        
+
         internal static void RegisterFunction(IPlugin plugin, string name, Delegate func)
         {
             var v = new ApiFuncRegister(plugin, name, func);
@@ -39,6 +39,18 @@ namespace CounterStrikeSharp.API.Core
                 throw new Exception($"cannot find plugin called '{moduleName}'");
             }
             return v.Function.DynamicInvoke(values);
+        }
+
+        public static object? TryCall(string moduleName, string funcName, object fallback, params object?[] values)
+        {
+            try
+            {
+                return Call(moduleName, funcName, values);
+            }
+            catch (Exception)
+            {
+                return fallback;
+            }
         }
 
         private class ApiFuncRegister


### PR DESCRIPTION
A short example here: 

Plugin A:
```cs
public override string ModuleName => "Plugin Name 1";

public override void Load(bool hotReload)
{
    base.Load(hotReload);
    this.RegisterSharedApi(nameof(TestWriteNumber), TestWriteNumber);
}

private int TestWriteNumber(int a, int b)
{
    int c = a + b;
    Console.WriteLine($"this is plugin A: {a}+{b}={c}");
    return c;
}
```

And in any other plugin:  
```cs
using CounterStrikeSharp.API.Core;

var obj = SharedPluginApi.TryCall("Plugin Name 1", "TestWriteNumber", fallback: 0, 1333, 808);
Console.WriteLine($"call from plugin B: {obj}");
```

`TryCall()` is one way of it.   
The other way is `Call()`, which would throw out if cant find the specific function or run into other error.   

The plugin creator can provide a "header" file for other people to use.   
no need to compile the header file into plugins.   
Others can just copy the header file code and paste into a .cs file in their own project.   

for example:   
```cs
using CounterStrikeSharp.API.Core;

internal static class PluginAHeader
{
    public static int TestWriteNumber(int a, int b)
    {
        var r = SharedPluginApi.TryCall("Plugin Name 1", "TestWriteNumber", fallback: 0, a, b);
        if (r == null) { return 0; }
        return (int)r;
    }
}
```

Screenshot:  
![image](https://github.com/roflmuffin/CounterStrikeSharp/assets/26303007/02435751-fb85-418b-a7b4-fe2e004afe2d)

I have not added event handlers between plugins yet.  
since it is more complex than just adding functions.   
I plan to add it after my idea was accepted.    

possibly function need to add also : `IsPluginLoaded()` , `IsApiExists()`. 

In fact, I can't wait to have this feature to commuicate between plugins.   
Before this, I used Reflection to get MethodInfo from another plugin, which wastes more performance than just managing it in CSS.API self.    
