### PR TITLE
[DNM] Added initial cross plugin communication functionality (via event handlers)

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Application.cs
+++ b/managed/CounterStrikeSharp.API/Core/Application.cs
@@ -82,6 +82,7 @@ namespace CounterStrikeSharp.API.Core
             AdminManager.AddCommands();
 
             _pluginManager.Load();
+            _pluginManager.PopulateLoadedPlugins();
 
             for (var i = 1; i <= 9; i++)
             {

--- a/managed/CounterStrikeSharp.API/Core/Attributes/Registration/PluginEventHandlerAttribute.cs
+++ b/managed/CounterStrikeSharp.API/Core/Attributes/Registration/PluginEventHandlerAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CounterStrikeSharp.API.Core.Attributes.Registration;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class PluginEventHandlerAttribute : Attribute
+{
+    
+}

--- a/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
@@ -399,14 +399,14 @@ namespace CounterStrikeSharp.API.Core
             RegisterEntityOutputAttributeHandlers(instance);
         }
 
-        public void SendPluginEvent(string name, object? data = null)
+        public void SendPluginEvent(string name, object[]? data = null)
         {
             LoadedPluginContexts.ToList().ForEach(pluginContext =>
             {
                 // Send plugin event to all plugins except this one
                 if (pluginContext.Plugin != this)
                 {
-                    pluginContext.Plugin.HandlePluginEvent(name, data ?? new object());
+                    pluginContext.Plugin.HandlePluginEvent(name, data ?? Array.Empty<object>());
                 }
             });
         }

--- a/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
@@ -399,7 +399,7 @@ namespace CounterStrikeSharp.API.Core
             RegisterEntityOutputAttributeHandlers(instance);
         }
 
-        protected void SendPluginEvent(string name, object? data)
+        public void SendPluginEvent(string name, object? data)
         {
             LoadedPluginContexts.ToList().ForEach(pluginContext =>
             {

--- a/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
@@ -399,7 +399,7 @@ namespace CounterStrikeSharp.API.Core
             RegisterEntityOutputAttributeHandlers(instance);
         }
 
-        public void SendPluginEvent(string name, object? data)
+        public void SendPluginEvent(string name, object? data = null)
         {
             LoadedPluginContexts.ToList().ForEach(pluginContext =>
             {

--- a/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/BasePlugin.cs
@@ -418,7 +418,7 @@ namespace CounterStrikeSharp.API.Core
                 var method = GetType()
                     .GetMethods()
                     .Where(method => method.GetCustomAttribute<PluginEventHandlerAttribute>() != null)
-                    .First(method => method.Name == "On" + ModuleName.Replace(" ", "") + name);
+                    .First(method => method.Name == "On" + name);
                 
                 method.Invoke(this, new[] { data });
             }

--- a/managed/CounterStrikeSharp.API/Core/IPlugin.cs
+++ b/managed/CounterStrikeSharp.API/Core/IPlugin.cs
@@ -15,6 +15,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using CounterStrikeSharp.API.Core.Plugin;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -57,9 +59,11 @@ namespace CounterStrikeSharp.API.Core
         ILogger Logger { get; set; }
         
         IStringLocalizer Localizer { get; set; }
+        HashSet<PluginContext> LoadedPluginContexts { get; set; }
 
         void RegisterAllAttributes(object instance);
 
         void InitializeConfig(object instance, Type pluginType);
+        void HandlePluginEvent(string name, object data);
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Plugin/Host/IPluginManager.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/Host/IPluginManager.cs
@@ -7,4 +7,5 @@ public interface IPluginManager
     public void Load();
     public void LoadPlugin(string path);
     public IEnumerable<PluginContext> GetLoadedPlugins();
+    void PopulateLoadedPlugins();
 }

--- a/managed/CounterStrikeSharp.API/Core/Plugin/Host/IPluginManager.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/Host/IPluginManager.cs
@@ -7,5 +7,5 @@ public interface IPluginManager
     public void Load();
     public void LoadPlugin(string path);
     public IEnumerable<PluginContext> GetLoadedPlugins();
-    void PopulateLoadedPlugins();
+    public void PopulateLoadedPlugins();
 }

--- a/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs
@@ -45,6 +45,14 @@ public class PluginManager : IPluginManager
         return _loadedPluginContexts;
     }
 
+    public void PopulateLoadedPlugins()
+    {
+        foreach (var pluginContext in _loadedPluginContexts)
+        {
+            pluginContext.Plugin.LoadedPluginContexts = _loadedPluginContexts;
+        }
+    }
+
     public void LoadPlugin(string path)
     {
         var plugin = new PluginContext(_serviceProvider, _scriptHostConfiguration, path, _loadedPluginContexts.Select(x => x.PluginId).DefaultIfEmpty(0).Max() + 1);

--- a/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs
@@ -14,7 +14,6 @@
  *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
  */
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs
@@ -14,6 +14,7 @@
  *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;


### PR DESCRIPTION
**This has NOT been tested yet**
This is more of a brain dump / proof of concept (I think) PR.

## Things to consider
- How to handle plugin event name clashes
- This means that all plugins can see / access all other plugins

# Example: **without data**
Event sending example (plugin 1):
```c#
SendPluginEvent("RetakesSpawnsComplete");
```

Event handling example (plugin 2):
```c#
[PluginEventHandler]
public void OnRetakesSpawnsComplete()
{
    // Do something now retakes spawns are complete.
}
```

# Example: **with data**
Event sending example (plugin 1):
```c#
SendPluginEvent("RetakesBombsiteSelected", new object[] { "A" });
```

Event handling example (plugin 2):
```c#
[PluginEventHandler]
public void OnRetakesSpawnsComplete(object[] data)
{
    // Do something with the bombsite data.
}
```