### PR TITLE
Add casted property .Team to CCSPlayerController

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
@@ -18,13 +18,7 @@ public partial class CCSPlayerController
         }
     }
     
-    public CsTeam Team
-    {
-        get
-        {
-            return (CsTeam)this.TeamNum;
-        }
-    }
+    public CsTeam Team => (CsTeam)this.TeamNum;
 
     public IntPtr GiveNamedItem(string item)
     {

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
@@ -17,6 +17,14 @@ public partial class CCSPlayerController
             return NativeAPI.GetUseridFromIndex((int)this.Index);
         }
     }
+    
+    public CsTeam Team
+    {
+        get
+        {
+            return (CsTeam)this.TeamNum;
+        }
+    }
 
     public IntPtr GiveNamedItem(string item)
     {


### PR DESCRIPTION
This means that people don't have to constantly cast the `player.TeamNum` to CsTeam in their plugins.