### PR TITLE
Log exception if plugin load fails using the `load` command

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Application.cs
+++ b/managed/CounterStrikeSharp.API/Core/Application.cs
@@ -182,6 +182,7 @@ namespace CounterStrikeSharp.API.Core
                         catch (Exception e)
                         {
                             info.ReplyToCommand($"Could not load plugin \"{path}\")", true);
+                            Logger.LogError(e, "Could not load plugin \"{Path}\"", path);
                         }
                     }
                     else


### PR DESCRIPTION
I've realized this might be missing.
Caught me as i was mostly hot-reloading my plugins during development. 