### PR TITLE
fix(Offsets/Win): CCSPlayer_ItemServices.RemoveWeapons()

### DIFF
--- a/configs/addons/counterstrikesharp/gamedata/gamedata.json
+++ b/configs/addons/counterstrikesharp/gamedata/gamedata.json
@@ -82,7 +82,7 @@
   },
   "CCSPlayer_ItemServices_RemoveWeapons": {
       "offsets": {
-          "windows": 21,
+          "windows": 19,
           "linux": 20
       }
   },


### PR DESCRIPTION
Fixes #250 

It looks like the windows VTable is padded with some random values, which the 21 offset was trying to hook, leading to the MemoryAccess Exceptions.