### PR TITLE
Admin manager improvements

### DIFF
--- a/managed/CounterStrikeSharp.API.Tests/AdminTests.cs
+++ b/managed/CounterStrikeSharp.API.Tests/AdminTests.cs
@@ -27,9 +27,9 @@ public class AdminTests
     {
         var adminData = AdminManager.GetPlayerAdminData((SteamID)76561197960265731);
         Assert.NotNull(adminData);
-        Assert.Equal(125u, adminData.Immunity); // Group immunity is 125, Admin immunity is 100
+        Assert.Equal(125u, AdminManager.GetPlayerImmunity((SteamID)76561197960265731)); // Group immunity is 125, Admin immunity is 100
         AdminManager.SetPlayerImmunity((SteamID)76561197960265731, 150u);
-        Assert.Equal(150u, adminData.Immunity); // Group immunity is 125, Admin immunity is 100
+        Assert.Equal(150u, AdminManager.GetPlayerImmunity((SteamID)76561197960265731)); // Group immunity is 125, Admin immunity is 100
     }
     
     [Fact]

--- a/managed/CounterStrikeSharp.API/Modules/Admin/AdminGroup.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Admin/AdminGroup.cs
@@ -95,7 +95,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
             // This is here for cases where the server console is attempting to call commands.
             // The server console should have access to all commands, regardless of groups.
             if (player == null) return true;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) { return false; }
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) { return false; }
 
             var playerData = GetPlayerAdminData(player.AuthorizedSteamID);
             if (playerData == null) return false;
@@ -136,20 +136,20 @@ namespace CounterStrikeSharp.API.Modules.Admin
             return playerData.Groups.IsSupersetOf(playerGroups);
         }
 
-        /// <summary>
-        /// Adds a player to a group.
-        /// </summary>
-        /// <param name="player">Player controller.</param>
-        /// <param name="groups">Groups to add the player to.</param>
-        public static void AddPlayerToGroup(CCSPlayerController? player, params string[] groups)
+		/// <summary>
+		/// Adds a player to a group. This does NOT modify the immunity of the player (see SetPlayerImmunity).
+		/// </summary>
+		/// <param name="player">Player controller.</param>
+		/// <param name="groups">Groups to add the player to.</param>
+		public static void AddPlayerToGroup(CCSPlayerController? player, params string[] groups)
         {
             if (player == null) return;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) { return; }
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) { return; }
             AddPlayerToGroup(player.AuthorizedSteamID, groups);
         }
 
         /// <summary>
-        /// Adds a player to a group.
+        /// Adds a player to a group. This does NOT modify the immunity of the player (see SetPlayerImmunity).
         /// </summary>
         /// <param name="steamId">SteamID of the player.</param>
         /// <param name="groups">Groups to add the player to.</param>
@@ -187,7 +187,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
         public static void RemovePlayerFromGroup(CCSPlayerController? player, bool removeInheritedFlags = true, params string[] groups)
         {
             if (player == null) return;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) { return; }
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) { return; }
             RemovePlayerFromGroup(player.AuthorizedSteamID, true, groups);
         }
 

--- a/managed/CounterStrikeSharp.API/Modules/Admin/AdminPermissions.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Admin/AdminPermissions.cs
@@ -167,22 +167,43 @@ namespace CounterStrikeSharp.API.Modules.Admin
             }
         }
 
-        /// <summary>
-        /// Grabs the admin data for a player that was loaded from "configs/admins.json".
-        /// </summary>
-        /// <param name="steamId">SteamID object of the player.</param>
-        /// <returns>AdminData class if data found, null if not.</returns>
-        public static AdminData? GetPlayerAdminData(SteamID? steamId)
+		/// <summary>
+		/// Grabs the admin data for a player that was loaded from "configs/admins.json" and "configs/admins_groups.json".
+		/// </summary>
+		/// <param name="player">Player controller</param>
+		/// <returns>AdminData class if data found, null if not.</returns>
+		public static AdminData? GetPlayerAdminData(CCSPlayerController? player)
+		{
+			if (player == null) return null;
+            return GetPlayerAdminData(player.AuthorizedSteamID);
+		}
+
+		/// <summary>
+		/// Grabs the admin data for a player that was loaded from "configs/admins.json" and "configs/admins_groups.json".
+		/// </summary>
+		/// <param name="steamId">SteamID object of the player.</param>
+		/// <returns>AdminData class if data found, null if not.</returns>
+		public static AdminData? GetPlayerAdminData(SteamID? steamId)
         {
             if (steamId == null) return null;
             return Admins.GetValueOrDefault(steamId);
         }
 
-        /// <summary>
-        /// Removes a players admin data. This is not saved to "configs/admins.json"
-        /// </summary>
-        /// <param name="steamId">Steam ID remove admin data from.</param>
-        public static void RemovePlayerAdminData(SteamID? steamId)
+		/// <summary>
+		/// Removes a players admin data. This is not saved to "configs/admins.json"
+		/// </summary>
+		/// <param name="player">Player controller</param>
+		public static void RemovePlayerAdminData(CCSPlayerController? player)
+		{
+			if (player == null) return;
+			RemovePlayerAdminData(player.AuthorizedSteamID);
+		}
+
+		/// <summary>
+		/// Removes a players admin data. This is not saved to "configs/admins.json"
+		/// </summary>
+		/// <param name="steamId">Steam ID remove admin data from.</param>
+		public static void RemovePlayerAdminData(SteamID? steamId)
         {
             if (steamId == null) return;
             Admins.Remove(steamId);
@@ -201,7 +222,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
             // This is here for cases where the server console is attempting to call commands.
             // The server console should have access to all commands, regardless of permissions.
             if (player == null) return true;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) { return false; }
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) { return false; }
             return PlayerHasPermissions(player.AuthorizedSteamID, flags);
         }
 
@@ -260,7 +281,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
             // This is here for cases where the server console is attempting to call commands.
             // The server console should have access to all commands, regardless of permissions.
             if (player == null) return true;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) { return false; }
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) { return false; }
             var playerData = GetPlayerAdminData(player.AuthorizedSteamID);
             return playerData?.CommandOverrides.ContainsKey(command) ?? false;
         }
@@ -290,7 +311,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
             // This is here for cases where the server console is attempting to call commands.
             // The server console should have access to all commands, regardless of permissions.
             if (player == null) return true;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) { return false; }
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) { return false; }
             var playerData = GetPlayerAdminData(player.AuthorizedSteamID);
             return playerData?.CommandOverrides.GetValueOrDefault(command) ?? false;
         }
@@ -319,7 +340,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
             // This is here for cases where the server console is attempting to call commands.
             // The server console should have access to all commands, regardless of permissions.
             if (player == null) return;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) { return; }
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) { return; }
             SetPlayerCommandOverride(player.AuthorizedSteamID, command, state);
         }
 
@@ -362,7 +383,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
         public static void AddPlayerPermissions(CCSPlayerController? player, params string[] flags)
         {
             if (player == null) return;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) return;
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) return;
             AddPlayerPermissions(player.AuthorizedSteamID, flags);
         }
         
@@ -400,7 +421,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
         public static void RemovePlayerPermissions(CCSPlayerController? player, params string[] flags)
         {
             if (player == null) return;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) return;
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) return;
 
             RemovePlayerPermissions(player.AuthorizedSteamID, flags);
         }
@@ -427,7 +448,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
         public static void ClearPlayerPermissions(CCSPlayerController? player)
         {
             if (player == null) return;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) return;
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) return;
 
             ClearPlayerPermissions(player.AuthorizedSteamID);
         }
@@ -457,7 +478,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
         public static void SetPlayerImmunity(CCSPlayerController? player, uint value)
         {
             if (player == null) return;
-            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot) return;
+            if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) return;
 
             SetPlayerImmunity(player.AuthorizedSteamID, value);
         }
@@ -477,13 +498,44 @@ namespace CounterStrikeSharp.API.Modules.Admin
             Admins[steamId] = data;
         }
 
-        /// <summary>
-        /// Checks to see if a player can target another player based on their immunity value.
-        /// </summary>
-        /// <param name="caller">Caller of the command.</param>
-        /// <param name="target">Target of the command.</param>
-        /// <returns></returns>
-        public static bool CanPlayerTarget(CCSPlayerController? caller, CCSPlayerController? target)
+		/// <summary>
+		/// Returns the immunity value for a player.
+		/// </summary>
+		/// <param name="player">Player controller.</param>
+		/// <returns> If an immunity value is present in "configs/admins_groups.json" 
+        /// and in "configs/admins.json", the returned value will be the greater of the two.
+        /// If the value is overriden with SetPlayerImmunity, that value is returned instead.</returns>
+		public static uint GetPlayerImmunity(CCSPlayerController? player)
+        {
+            if (player == null) return 0;
+			if (!player.IsValid || player.Connected != PlayerConnectedState.PlayerConnected || player.IsBot || player.IsHLTV) return 0;
+
+            return GetPlayerImmunity(player.AuthorizedSteamID);
+		}
+
+		/// <summary>
+		/// Returns the immunity value for a player.
+		/// </summary>
+		/// <param name="steamId">Steam ID of the player.</param>
+		/// <returns> If an immunity value is present in "configs/admins_groups.json" 
+		/// and in "configs/admins.json", the returned value will be the greater of the two.
+		/// If the value is overriden with SetPlayerImmunity, that value is returned instead.</returns>
+		public static uint GetPlayerImmunity(SteamID? steamId)
+        {
+			if (steamId == null) return 0;
+			var data = GetPlayerAdminData(steamId);
+			if (data == null) return 0;
+
+            return data.Immunity;
+		}
+
+		/// <summary>
+		/// Checks to see if a player can target another player based on their immunity value.
+		/// </summary>
+		/// <param name="caller">Caller of the command.</param>
+		/// <param name="target">Target of the command.</param>
+		/// <returns></returns>
+		public static bool CanPlayerTarget(CCSPlayerController? caller, CCSPlayerController? target)
         {
             // The server console should be able to target everyone.
             if (caller == null) return true;

--- a/managed/CounterStrikeSharp.API/Modules/Commands/Targeting/Target.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Commands/Targeting/Target.cs
@@ -90,11 +90,11 @@ public class Target
             case TargetType.TeamSpec:
                 return player.TeamNum == (byte)CsTeam.Spectator;
             case TargetType.GroupAll:
-                return true;
+                return !player.IsHLTV;
             case TargetType.GroupBots:
                 return player.IsBot;
             case TargetType.GroupHumans:
-                return !player.IsBot;
+                return !player.IsBot && !player.IsHLTV;
             case TargetType.GroupAlive:
                 return player.PlayerPawn is { IsValid: true, Value.LifeState: (byte)LifeState_t.LIFE_ALIVE };
             case TargetType.GroupDead:


### PR DESCRIPTION
A few additions after a conversation on Discord:
- Updated comments for AddPlayerToGroup 
- Added player controller equivalent for GetPlayerAdminData and RemovePlayerAdminData
- Added GetPlayerImmunity
- Prevent HLTV player controller from being passed into admin-related functions
- Changed TargetType.GroupAll TargetPredicate to exclude HLTV

I've decided to exclude the HLTV player from these functions as they do not have a physical presence in the world and shouldn't be manipulated with commands.