### PR TITLE
feat: add CommandCallingContext to commands

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -1,6 +1,7 @@
 
 using System;
 using CounterStrikeSharp.API.Modules.Memory;
+using CounterStrikeSharp.API.Modules.Commands;
 
 namespace CounterStrikeSharp.API.Core
 {
@@ -121,6 +122,17 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
 			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			}
+		}
+
+        public static CommandCallingContext CommandGetCallingContext(IntPtr command){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x886D0EB6);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			return (CommandCallingContext)ScriptContext.GlobalScriptContext.GetResult(typeof(CommandCallingContext));
 			}
 		}
 

--- a/managed/CounterStrikeSharp.API/Core/Application.cs
+++ b/managed/CounterStrikeSharp.API/Core/Application.cs
@@ -112,7 +112,7 @@ namespace CounterStrikeSharp.API.Core
                 "  CounterStrikeSharp was created and is maintained by Michael \"roflmuffin\" Wilson.\n" +
                 "  Counter-Strike Sharp uses code borrowed from SourceMod, Source.Python, FiveM, Saul Rennison, source2gen and CS2Fixes.\n" +
                 "  See ACKNOWLEDGEMENTS.md for more information.\n" +
-                "  Current API Version: " + currentVersion, true);
+                "  Current API Version: " + currentVersion);
             return;
         }
 
@@ -124,8 +124,7 @@ namespace CounterStrikeSharp.API.Core
                 case "list":
                 {
                     info.ReplyToCommand(
-                        $"  List of all plugins currently loaded by CounterStrikeSharp: {_pluginManager.GetLoadedPlugins().Count()} plugins loaded.",
-                        true);
+                        $"  List of all plugins currently loaded by CounterStrikeSharp: {_pluginManager.GetLoadedPlugins().Count()} plugins loaded.");
 
                     foreach (var plugin in _pluginManager.GetLoadedPlugins())
                     {
@@ -142,7 +141,7 @@ namespace CounterStrikeSharp.API.Core
                             sb.Append(plugin.Plugin.ModuleDescription);
                         }
 
-                        info.ReplyToCommand(sb.ToString(), true);
+                        info.ReplyToCommand(sb.ToString());
                     }
 
                     break;
@@ -153,8 +152,7 @@ namespace CounterStrikeSharp.API.Core
                     if (info.ArgCount < 3)
                     {
                         info.ReplyToCommand(
-                            "Valid usage: css_plugins start/load [relative plugin path || absolute plugin path] (e.g \"TestPlugin\", \"plugins/TestPlugin/TestPlugin.dll\")\n",
-                            true);
+                            "Valid usage: css_plugins start/load [relative plugin path || absolute plugin path] (e.g \"TestPlugin\", \"plugins/TestPlugin/TestPlugin.dll\")\n");
                         break;
                     }
 
@@ -180,7 +178,7 @@ namespace CounterStrikeSharp.API.Core
                         }
                         catch (Exception e)
                         {
-                            info.ReplyToCommand($"Could not load plugin \"{path}\"", true);
+                            info.ReplyToCommand($"Could not load plugin \"{path}\"");
                             Logger.LogError(e, "Could not load plugin \"{Path}\"", path);
                         }
                     }
@@ -198,8 +196,7 @@ namespace CounterStrikeSharp.API.Core
                     if (info.ArgCount < 3)
                     {
                         info.ReplyToCommand(
-                            "Valid usage: css_plugins stop/unload [plugin name || #plugin id] (e.g \"TestPlugin\", \"1\")\n",
-                            true);
+                            "Valid usage: css_plugins stop/unload [plugin name || #plugin id] (e.g \"TestPlugin\", \"1\")\n");
                         break;
                     }
 
@@ -207,7 +204,7 @@ namespace CounterStrikeSharp.API.Core
                     IPluginContext? plugin = _pluginContextQueryHandler.FindPluginByIdOrName(pluginIdentifier);
                     if (plugin == null)
                     {
-                        info.ReplyToCommand($"Could not unload plugin \"{pluginIdentifier}\"", true);
+                        info.ReplyToCommand($"Could not unload plugin \"{pluginIdentifier}\"");
                         break;
                     }
 
@@ -221,8 +218,7 @@ namespace CounterStrikeSharp.API.Core
                     if (info.ArgCount < 3)
                     {
                         info.ReplyToCommand(
-                            "Valid usage: css_plugins restart/reload [plugin name || #plugin id] (e.g \"TestPlugin\", \"#1\")\n",
-                            true);
+                            "Valid usage: css_plugins restart/reload [plugin name || #plugin id] (e.g \"TestPlugin\", \"#1\")\n");
                         break;
                     }
 
@@ -231,7 +227,7 @@ namespace CounterStrikeSharp.API.Core
 
                     if (plugin == null)
                     {
-                        info.ReplyToCommand($"Could not reload plugin \"{pluginIdentifier}\"", true);
+                        info.ReplyToCommand($"Could not reload plugin \"{pluginIdentifier}\"");
                         break;
                     }
 
@@ -245,8 +241,7 @@ namespace CounterStrikeSharp.API.Core
                                         "  list - List all plugins currently loaded.\n" +
                                         "  start / load - Loads a plugin not currently loaded.\n" +
                                         "  stop / unload - Unloads a plugin currently loaded.\n" +
-                                        "  restart / reload - Reloads a plugin currently loaded."
-                        , true);
+                                        "  restart / reload - Reloads a plugin currently loaded.");
                     break;
             }
         }

--- a/managed/CounterStrikeSharp.API/Modules/Commands/CommandCallingContext.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Commands/CommandCallingContext.cs
@@ -1,0 +1,7 @@
+﻿namespace CounterStrikeSharp.API.Modules.Commands;
+
+public enum CommandCallingContext
+{
+    Console = 0,
+    Chat = 1
+}

--- a/managed/CounterStrikeSharp.API/Modules/Commands/CommandInfo.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Commands/CommandInfo.cs
@@ -44,10 +44,37 @@ namespace CounterStrikeSharp.API.Modules.Commands
         public string ArgByIndex(int index) => NativeAPI.CommandGetArgByIndex(Handle, index);
         public string GetArg(int index) => NativeAPI.CommandGetArgByIndex(Handle, index);
         
+        /// <summary>
+        /// Whether or not the command was sent via Console or Chat.
+        /// </summary>
+        public CommandCallingContext CallingContext => NativeAPI.CommandGetCallingContext(Handle);
+        
+        [Obsolete("Console parameter is now automatically set based on the context of the command.", true)]
         public void ReplyToCommand(string message, bool console = false) {
             if (CallingPlayer != null) 
             {
                 if (console) { CallingPlayer.PrintToConsole(message); }
+                else CallingPlayer.PrintToChat(message);
+            }
+            else 
+            {
+                Server.PrintToConsole(message);    
+            }
+        }
+
+        /// <summary>
+        /// Replies to the command with a message.
+        /// <remarks>
+        /// If the command was sent via Chat, <see cref="CCSPlayerController.PrintToChat"/> is used, otherwise <see cref="CCSPlayerController.PrintToConsole"/> is used.
+        /// If sent from the server console/RCON, <see cref="Server.PrintToConsole"/> is used.
+        /// </remarks>
+        /// </summary>
+        /// <param name="message">Message to send</param>
+        public void ReplyToCommand(string message)
+        {
+            if (CallingPlayer != null) 
+            {
+                if (CallingContext == CommandCallingContext.Console) { CallingPlayer.PrintToConsole(message); }
                 else CallingPlayer.PrintToChat(message);
             }
             else 

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -530,7 +530,7 @@ namespace TestPlugin
         [ConsoleCommand("cssharp_attribute", "This is a custom attribute event")]
         public void OnCommand(CCSPlayerController? player, CommandInfo command)
         {
-            command.ReplyToCommand("cssharp_attribute called", true);
+            command.ReplyToCommand("cssharp_attribute called");
         }
 
         [ConsoleCommand("css_changelevel", "Changes map")]

--- a/src/core/managers/chat_manager.cpp
+++ b/src/core/managers/chat_manager.cpp
@@ -114,7 +114,7 @@ void ChatManager::InternalDispatch(CBaseEntity* pPlayerController, const char* s
     if (pPlayerController == nullptr) {
         globals::conCommandManager.ExecuteCommandCallbacks(
             fullCommand.Arg(0), CCommandContext(CommandTarget_t::CT_NO_TARGET, CPlayerSlot(-1)),
-            fullCommand, HookMode::Pre);
+            fullCommand, HookMode::Pre, CommandCallingContext::Chat);
         return;
     }
 
@@ -123,6 +123,6 @@ void ChatManager::InternalDispatch(CBaseEntity* pPlayerController, const char* s
 
     globals::conCommandManager.ExecuteCommandCallbacks(
         fullCommand.Arg(0), CCommandContext(CommandTarget_t::CT_NO_TARGET, slot), fullCommand,
-        HookMode::Pre);
+        HookMode::Pre, CommandCallingContext::Chat);
 }
 } // namespace counterstrikesharp

--- a/src/core/managers/con_command_manager.cpp
+++ b/src/core/managers/con_command_manager.cpp
@@ -309,7 +309,7 @@ bool ConCommandManager::RemoveValveCommand(const char* name)
 }
 
 HookResult ConCommandManager::ExecuteCommandCallbacks(const char* name, const CCommandContext& ctx,
-                                                      const CCommand& args, HookMode mode)
+                                                      const CCommand& args, HookMode mode, CommandCallingContext callingContext)
 {
     CSSHARP_CORE_TRACE("[ConCommandManager::ExecuteCommandCallbacks][{}]: {}",
                        mode == Pre ? "Pre" : "Post", name);
@@ -318,6 +318,8 @@ HookResult ConCommandManager::ExecuteCommandCallbacks(const char* name, const CC
     HookResult result = HookResult::Continue;
 
     auto globalCallback = mode == HookMode::Pre ? m_global_cmd.callback_pre : m_global_cmd.callback_post;
+
+    m_cmd_contexts[&args] = callingContext;
 
     if (globalCallback->GetFunctionCount() > 0) {
         globalCallback->ScriptContext().Reset();
@@ -370,6 +372,8 @@ HookResult ConCommandManager::ExecuteCommandCallbacks(const char* name, const CC
         }
     }
 
+    m_cmd_contexts.erase(&args);
+
     return result;
 }
 
@@ -380,7 +384,7 @@ void ConCommandManager::Hook_DispatchConCommand(ConCommandHandle cmd, const CCom
 
     CSSHARP_CORE_TRACE("[ConCommandManager::Hook_DispatchConCommand]: {}", name);
 
-    auto result = ExecuteCommandCallbacks(name, ctx, args, HookMode::Pre);
+    auto result = ExecuteCommandCallbacks(name, ctx, args, HookMode::Pre, CommandCallingContext::Console);
     if (result >= HookResult::Handled) {
         RETURN_META(MRES_SUPERCEDE);
     }
@@ -391,7 +395,7 @@ void ConCommandManager::Hook_DispatchConCommand_Post(ConCommandHandle cmd,
 {
     const char* name = args.Arg(0);
 
-    auto result = ExecuteCommandCallbacks(name, ctx, args, HookMode::Post);
+    auto result = ExecuteCommandCallbacks(name, ctx, args, HookMode::Post, CommandCallingContext::Console);
     if (result >= HookResult::Handled) {
         RETURN_META(MRES_SUPERCEDE);
     }
@@ -399,6 +403,10 @@ void ConCommandManager::Hook_DispatchConCommand_Post(ConCommandHandle cmd,
 bool ConCommandManager::IsValidValveCommand(const char* name) {
     ConCommandHandle pCmd = globals::cvars->FindCommand(name);
     return pCmd.IsValid();
+}
+
+CommandCallingContext ConCommandManager::GetCommandCallingContext(CCommand* args) {
+    return m_cmd_contexts[args];
 }
 
 } // namespace counterstrikesharp

--- a/src/core/managers/con_command_manager.cpp
+++ b/src/core/managers/con_command_manager.cpp
@@ -349,6 +349,7 @@ HookResult ConCommandManager::ExecuteCommandCallbacks(const char* name, const CC
     }
 
     if (!pInfo) {
+        m_cmd_contexts.erase(&args);
         return result;
     }
 
@@ -366,6 +367,7 @@ HookResult ConCommandManager::ExecuteCommandCallbacks(const char* name, const CC
         auto thisResult = pCallback->ScriptContext().GetResult<HookResult>();
 
         if (thisResult >= HookResult::Handled) {
+            m_cmd_contexts.erase(&args);
             return thisResult;
         } else if (thisResult > result) {
             result = thisResult;

--- a/src/core/managers/con_command_manager.h
+++ b/src/core/managers/con_command_manager.h
@@ -53,6 +53,11 @@ struct CaseInsensitiveComparator {
 namespace counterstrikesharp {
 class ScriptCallback;
 
+enum CommandCallingContext {
+    Console = 0,
+    Chat = 1,
+};
+
 class ConCommandInfo {
     friend class ConCommandManager;
 
@@ -91,11 +96,13 @@ public:
     void Hook_DispatchConCommand(ConCommandHandle cmd, const CCommandContext& ctx, const CCommand& args);
     void Hook_DispatchConCommand_Post(ConCommandHandle cmd, const CCommandContext& ctx, const CCommand& args);
     HookResult ExecuteCommandCallbacks(const char* name, const CCommandContext& ctx,
-                                       const CCommand& args, HookMode mode);
+                                       const CCommand& args, HookMode mode, CommandCallingContext callingContext);
 
+    CommandCallingContext GetCommandCallingContext(CCommand* args);
 private:
     std::vector<ConCommandInfo*> m_cmd_list;
     std::map<std::string, ConCommandInfo*, CaseInsensitiveComparator> m_cmd_lookup;
+    std::map<const CCommand*, CommandCallingContext> m_cmd_contexts;
     ConCommandInfo m_global_cmd = ConCommandInfo(true);
 };
 

--- a/src/core/managers/player_manager.cpp
+++ b/src/core/managers/player_manager.cpp
@@ -314,7 +314,7 @@ void PlayerManager::OnClientCommand(CPlayerSlot slot, const CCommand& args) cons
     globals::voiceManager.OnClientCommand(slot, args);
 
     auto result = globals::conCommandManager.ExecuteCommandCallbacks(
-        cmd, CCommandContext(CommandTarget_t::CT_NO_TARGET, slot), args, HookMode::Pre);
+        cmd, CCommandContext(CommandTarget_t::CT_NO_TARGET, slot), args, HookMode::Pre, CommandCallingContext::Console);
 
     if (result >= HookResult::Handled) {
         RETURN_META(MRES_SUPERCEDE);

--- a/src/scripting/natives/natives_commands.cpp
+++ b/src/scripting/natives/natives_commands.cpp
@@ -118,6 +118,13 @@ static const char* CommandGetArgByIndex(ScriptContext& script_context)
     return command->Arg(index);
 }
 
+static CommandCallingContext CommandGetCallingContext(ScriptContext& script_context)
+{
+    auto* command = script_context.GetArgument<CCommand*>(0);
+
+    return globals::conCommandManager.GetCommandCallingContext(command);
+}
+
 static void IssueClientCommand(ScriptContext& script_context)
 {
     auto slot = script_context.GetArgument<int>(0);
@@ -194,6 +201,7 @@ REGISTER_NATIVES(commands, {
     ScriptEngine::RegisterNativeHandler("COMMAND_GET_ARG_STRING", CommandGetArgString);
     ScriptEngine::RegisterNativeHandler("COMMAND_GET_COMMAND_STRING", CommandGetCommandString);
     ScriptEngine::RegisterNativeHandler("COMMAND_GET_ARG_BY_INDEX", CommandGetArgByIndex);
+    ScriptEngine::RegisterNativeHandler("COMMAND_GET_CALLING_CONTEXT", CommandGetCallingContext);
 
     ScriptEngine::RegisterNativeHandler("FIND_CONVAR", FindConVar);
     ScriptEngine::RegisterNativeHandler("SET_CONVAR_STRING_VALUE", SetConVarStringValue);

--- a/src/scripting/natives/natives_commands.yaml
+++ b/src/scripting/natives/natives_commands.yaml
@@ -6,6 +6,7 @@ COMMAND_GET_ARG_COUNT: command:pointer -> int
 COMMAND_GET_ARG_STRING: command:pointer -> string
 COMMAND_GET_COMMAND_STRING: command:pointer -> string
 COMMAND_GET_ARG_BY_INDEX: command:pointer,index:int -> string
+COMMAND_GET_CALLING_CONTEXT: command:pointer -> CommandCallingContext
 ISSUE_CLIENT_COMMAND: slot:int,command:string -> void
 ISSUE_CLIENT_COMMAND_FROM_SERVER: slot:int,command:string -> void
 FIND_CONVAR: name:string -> pointer

--- a/tooling/CodeGen.Natives/Mapping.cs
+++ b/tooling/CodeGen.Natives/Mapping.cs
@@ -67,6 +67,8 @@ public class Mapping
                 return "ListenOverride";
             case "DataType_t":
                 return "DataType";
+            case "CommandCallingContext":
+                return "CommandCallingContext";
             case "any":
                 return "T";
         }

--- a/tooling/CodeGen.Natives/Scripts/GenerateNatives.cs
+++ b/tooling/CodeGen.Natives/Scripts/GenerateNatives.cs
@@ -91,6 +91,7 @@ public partial class Generators
         var result = $@"
 using System;
 using CounterStrikeSharp.API.Modules.Memory;
+using CounterStrikeSharp.API.Modules.Commands;
 
 namespace CounterStrikeSharp.API.Core
 {{


### PR DESCRIPTION
Adds command context (chat or console) to `CommandInfo` so it can be used to determine where `ReplyToCommand` should send the message automatically. This deprecates the overloaded `console = true` default param for existing `ReplyToCommand`.

Closes #77