### PR TITLE
fix: handle byte array schema properties correctly

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CBaseIssue.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CBaseIssue.g.cs
@@ -23,7 +23,7 @@ public partial class CBaseIssue : NativeObject
 	public string TypeString
 	{
 		get { return Schema.GetString(this.Handle, "CBaseIssue", "m_szTypeString"); }
-		set { Schema.SetString(this.Handle, "CBaseIssue", "m_szTypeString", value); }
+		set { Schema.SetStringBytes(this.Handle, "CBaseIssue", "m_szTypeString", value, 64); }
 	}
 
 	// m_szDetailsString
@@ -31,7 +31,7 @@ public partial class CBaseIssue : NativeObject
 	public string DetailsString
 	{
 		get { return Schema.GetString(this.Handle, "CBaseIssue", "m_szDetailsString"); }
-		set { Schema.SetString(this.Handle, "CBaseIssue", "m_szDetailsString", value); }
+		set { Schema.SetStringBytes(this.Handle, "CBaseIssue", "m_szDetailsString", value, 260); }
 	}
 
 	// m_iNumYesVotes

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CBasePlayerController.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CBasePlayerController.g.cs
@@ -55,7 +55,7 @@ public partial class CBasePlayerController : CBaseEntity
 	public string PlayerName
 	{
 		get { return Schema.GetString(this.Handle, "CBasePlayerController", "m_iszPlayerName"); }
-		set { Schema.SetString(this.Handle, "CBasePlayerController", "m_iszPlayerName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CBasePlayerController", "m_iszPlayerName", value, 128); }
 	}
 
 	// m_szNetworkIDString

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSBot.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSBot.g.cs
@@ -31,7 +31,7 @@ public partial class CCSBot : CBot
 	public string Name
 	{
 		get { return Schema.GetString(this.Handle, "CCSBot", "m_name"); }
-		set { Schema.SetString(this.Handle, "CCSBot", "m_name", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSBot", "m_name", value, 64); }
 	}
 
 	// m_combatRange

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSGameRules.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSGameRules.g.cs
@@ -195,7 +195,7 @@ public partial class CCSGameRules : CTeamplayRules
 	public string TournamentEventName
 	{
 		get { return Schema.GetString(this.Handle, "CCSGameRules", "m_szTournamentEventName"); }
-		set { Schema.SetString(this.Handle, "CCSGameRules", "m_szTournamentEventName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSGameRules", "m_szTournamentEventName", value, 512); }
 	}
 
 	// m_szTournamentEventStage
@@ -203,7 +203,7 @@ public partial class CCSGameRules : CTeamplayRules
 	public string TournamentEventStage
 	{
 		get { return Schema.GetString(this.Handle, "CCSGameRules", "m_szTournamentEventStage"); }
-		set { Schema.SetString(this.Handle, "CCSGameRules", "m_szTournamentEventStage", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSGameRules", "m_szTournamentEventStage", value, 512); }
 	}
 
 	// m_szMatchStatTxt
@@ -211,7 +211,7 @@ public partial class CCSGameRules : CTeamplayRules
 	public string MatchStatTxt
 	{
 		get { return Schema.GetString(this.Handle, "CCSGameRules", "m_szMatchStatTxt"); }
-		set { Schema.SetString(this.Handle, "CCSGameRules", "m_szMatchStatTxt", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSGameRules", "m_szMatchStatTxt", value, 512); }
 	}
 
 	// m_szTournamentPredictionsTxt
@@ -219,7 +219,7 @@ public partial class CCSGameRules : CTeamplayRules
 	public string TournamentPredictionsTxt
 	{
 		get { return Schema.GetString(this.Handle, "CCSGameRules", "m_szTournamentPredictionsTxt"); }
-		set { Schema.SetString(this.Handle, "CCSGameRules", "m_szTournamentPredictionsTxt", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSGameRules", "m_szTournamentPredictionsTxt", value, 512); }
 	}
 
 	// m_nTournamentPredictionsPct

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSPlayerController.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSPlayerController.g.cs
@@ -111,7 +111,7 @@ public partial class CCSPlayerController : CBasePlayerController
 	public string ClanName
 	{
 		get { return Schema.GetString(this.Handle, "CCSPlayerController", "m_szClanName"); }
-		set { Schema.SetString(this.Handle, "CCSPlayerController", "m_szClanName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSPlayerController", "m_szClanName", value, 32); }
 	}
 
 	// m_iCoachingTeam

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSPlayerPawn.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSPlayerPawn.g.cs
@@ -67,7 +67,7 @@ public partial class CCSPlayerPawn : CCSPlayerPawnBase
 	public string LastPlaceName
 	{
 		get { return Schema.GetString(this.Handle, "CCSPlayerPawn", "m_szLastPlaceName"); }
-		set { Schema.SetString(this.Handle, "CCSPlayerPawn", "m_szLastPlaceName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSPlayerPawn", "m_szLastPlaceName", value, 18); }
 	}
 
 	// m_bInHostageResetZone
@@ -199,7 +199,7 @@ public partial class CCSPlayerPawn : CCSPlayerPawnBase
 	public string RagdollDamageWeaponName
 	{
 		get { return Schema.GetString(this.Handle, "CCSPlayerPawn", "m_szRagdollDamageWeaponName"); }
-		set { Schema.SetString(this.Handle, "CCSPlayerPawn", "m_szRagdollDamageWeaponName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSPlayerPawn", "m_szRagdollDamageWeaponName", value, 64); }
 	}
 
 	// m_bRagdollDamageHeadshot

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSPlayerPawnBase.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSPlayerPawnBase.g.cs
@@ -243,7 +243,7 @@ public partial class CCSPlayerPawnBase : CBasePlayerPawn
 	public string MenuStringBuffer
 	{
 		get { return Schema.GetString(this.Handle, "CCSPlayerPawnBase", "m_MenuStringBuffer"); }
-		set { Schema.SetString(this.Handle, "CCSPlayerPawnBase", "m_MenuStringBuffer", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSPlayerPawnBase", "m_MenuStringBuffer", value, 1024); }
 	}
 
 	// m_fIntroCamTime

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSTeam.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CCSTeam.g.cs
@@ -35,7 +35,7 @@ public partial class CCSTeam : CTeam
 	public string TeamMatchStat
 	{
 		get { return Schema.GetString(this.Handle, "CCSTeam", "m_szTeamMatchStat"); }
-		set { Schema.SetString(this.Handle, "CCSTeam", "m_szTeamMatchStat", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSTeam", "m_szTeamMatchStat", value, 512); }
 	}
 
 	// m_numMapVictories
@@ -59,7 +59,7 @@ public partial class CCSTeam : CTeam
 	public string ClanTeamname
 	{
 		get { return Schema.GetString(this.Handle, "CCSTeam", "m_szClanTeamname"); }
-		set { Schema.SetString(this.Handle, "CCSTeam", "m_szClanTeamname", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSTeam", "m_szClanTeamname", value, 129); }
 	}
 
 	// m_iClanID
@@ -71,7 +71,7 @@ public partial class CCSTeam : CTeam
 	public string TeamFlagImage
 	{
 		get { return Schema.GetString(this.Handle, "CCSTeam", "m_szTeamFlagImage"); }
-		set { Schema.SetString(this.Handle, "CCSTeam", "m_szTeamFlagImage", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSTeam", "m_szTeamFlagImage", value, 8); }
 	}
 
 	// m_szTeamLogoImage
@@ -79,7 +79,7 @@ public partial class CCSTeam : CTeam
 	public string TeamLogoImage
 	{
 		get { return Schema.GetString(this.Handle, "CCSTeam", "m_szTeamLogoImage"); }
-		set { Schema.SetString(this.Handle, "CCSTeam", "m_szTeamLogoImage", value); }
+		set { Schema.SetStringBytes(this.Handle, "CCSTeam", "m_szTeamLogoImage", value, 8); }
 	}
 
 	// m_flNextResourceTime

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CColorCorrection.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CColorCorrection.g.cs
@@ -83,7 +83,7 @@ public partial class CColorCorrection : CBaseEntity
 	public string NetlookupFilename
 	{
 		get { return Schema.GetString(this.Handle, "CColorCorrection", "m_netlookupFilename"); }
-		set { Schema.SetString(this.Handle, "CColorCorrection", "m_netlookupFilename", value); }
+		set { Schema.SetStringBytes(this.Handle, "CColorCorrection", "m_netlookupFilename", value, 512); }
 	}
 
 	// m_lookupFilename

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CColorCorrectionVolume.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CColorCorrectionVolume.g.cs
@@ -43,7 +43,7 @@ public partial class CColorCorrectionVolume : CBaseTrigger
 	public string LookupFilename
 	{
 		get { return Schema.GetString(this.Handle, "CColorCorrectionVolume", "m_lookupFilename"); }
-		set { Schema.SetString(this.Handle, "CColorCorrectionVolume", "m_lookupFilename", value); }
+		set { Schema.SetStringBytes(this.Handle, "CColorCorrectionVolume", "m_lookupFilename", value, 512); }
 	}
 
 	// m_LastEnterWeight

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CEconItemView.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CEconItemView.g.cs
@@ -67,7 +67,7 @@ public partial class CEconItemView : IEconItemInterface
 	public string CustomName
 	{
 		get { return Schema.GetString(this.Handle, "CEconItemView", "m_szCustomName"); }
-		set { Schema.SetString(this.Handle, "CEconItemView", "m_szCustomName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CEconItemView", "m_szCustomName", value, 161); }
 	}
 
 	// m_szCustomNameOverride
@@ -75,7 +75,7 @@ public partial class CEconItemView : IEconItemInterface
 	public string CustomNameOverride
 	{
 		get { return Schema.GetString(this.Handle, "CEconItemView", "m_szCustomNameOverride"); }
-		set { Schema.SetString(this.Handle, "CEconItemView", "m_szCustomNameOverride", value); }
+		set { Schema.SetStringBytes(this.Handle, "CEconItemView", "m_szCustomNameOverride", value, 161); }
 	}
 
 }

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CEnvMicrophone.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CEnvMicrophone.g.cs
@@ -87,7 +87,7 @@ public partial class CEnvMicrophone : CPointEntity
 	public string LastSound
 	{
 		get { return Schema.GetString(this.Handle, "CEnvMicrophone", "m_szLastSound"); }
-		set { Schema.SetString(this.Handle, "CEnvMicrophone", "m_szLastSound", value); }
+		set { Schema.SetStringBytes(this.Handle, "CEnvMicrophone", "m_szLastSound", value, 256); }
 	}
 
 	// m_iLastRoutedFrame

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CEnvProjectedTexture.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CEnvProjectedTexture.g.cs
@@ -115,7 +115,7 @@ public partial class CEnvProjectedTexture : CModelPointEntity
 	public string SpotlightTextureName
 	{
 		get { return Schema.GetString(this.Handle, "CEnvProjectedTexture", "m_SpotlightTextureName"); }
-		set { Schema.SetString(this.Handle, "CEnvProjectedTexture", "m_SpotlightTextureName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CEnvProjectedTexture", "m_SpotlightTextureName", value, 512); }
 	}
 
 	// m_nSpotlightTextureFrame

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CGameRules.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CGameRules.g.cs
@@ -23,7 +23,7 @@ public partial class CGameRules : NativeObject
 	public string QuestName
 	{
 		get { return Schema.GetString(this.Handle, "CGameRules", "m_szQuestName"); }
-		set { Schema.SetString(this.Handle, "CGameRules", "m_szQuestName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CGameRules", "m_szQuestName", value, 128); }
 	}
 
 	// m_nQuestPhase

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CParticleSystem.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CParticleSystem.g.cs
@@ -23,7 +23,7 @@ public partial class CParticleSystem : CBaseModelEntity
 	public string SnapshotFileName
 	{
 		get { return Schema.GetString(this.Handle, "CParticleSystem", "m_szSnapshotFileName"); }
-		set { Schema.SetString(this.Handle, "CParticleSystem", "m_szSnapshotFileName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CParticleSystem", "m_szSnapshotFileName", value, 512); }
 	}
 
 	// m_bActive

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CPlayerPing.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CPlayerPing.g.cs
@@ -39,7 +39,7 @@ public partial class CPlayerPing : CBaseEntity
 	public string PlaceName
 	{
 		get { return Schema.GetString(this.Handle, "CPlayerPing", "m_szPlaceName"); }
-		set { Schema.SetString(this.Handle, "CPlayerPing", "m_szPlaceName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CPlayerPing", "m_szPlaceName", value, 18); }
 	}
 
 }

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CPointClientUIWorldTextPanel.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CPointClientUIWorldTextPanel.g.cs
@@ -23,7 +23,7 @@ public partial class CPointClientUIWorldTextPanel : CPointClientUIWorldPanel
 	public string MessageText
 	{
 		get { return Schema.GetString(this.Handle, "CPointClientUIWorldTextPanel", "m_messageText"); }
-		set { Schema.SetString(this.Handle, "CPointClientUIWorldTextPanel", "m_messageText", value); }
+		set { Schema.SetStringBytes(this.Handle, "CPointClientUIWorldTextPanel", "m_messageText", value, 512); }
 	}
 
 }

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CPointWorldText.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CPointWorldText.g.cs
@@ -23,7 +23,7 @@ public partial class CPointWorldText : CModelPointEntity
 	public string MessageText
 	{
 		get { return Schema.GetString(this.Handle, "CPointWorldText", "m_messageText"); }
-		set { Schema.SetString(this.Handle, "CPointWorldText", "m_messageText", value); }
+		set { Schema.SetStringBytes(this.Handle, "CPointWorldText", "m_messageText", value, 512); }
 	}
 
 	// m_FontName
@@ -31,7 +31,7 @@ public partial class CPointWorldText : CModelPointEntity
 	public string FontName
 	{
 		get { return Schema.GetString(this.Handle, "CPointWorldText", "m_FontName"); }
-		set { Schema.SetString(this.Handle, "CPointWorldText", "m_FontName", value); }
+		set { Schema.SetStringBytes(this.Handle, "CPointWorldText", "m_FontName", value, 64); }
 	}
 
 	// m_bEnabled

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CTeam.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CTeam.g.cs
@@ -35,7 +35,7 @@ public partial class CTeam : CBaseEntity
 	public string Teamname
 	{
 		get { return Schema.GetString(this.Handle, "CTeam", "m_szTeamname"); }
-		set { Schema.SetString(this.Handle, "CTeam", "m_szTeamname", value); }
+		set { Schema.SetStringBytes(this.Handle, "CTeam", "m_szTeamname", value, 129); }
 	}
 
 }

--- a/managed/CounterStrikeSharp.API/Core/Schema/Classes/CTriggerSndSosOpvar.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Schema/Classes/CTriggerSndSosOpvar.g.cs
@@ -75,7 +75,7 @@ public partial class CTriggerSndSosOpvar : CBaseTrigger
 	public string OpvarNameChar
 	{
 		get { return Schema.GetString(this.Handle, "CTriggerSndSosOpvar", "m_opvarNameChar"); }
-		set { Schema.SetString(this.Handle, "CTriggerSndSosOpvar", "m_opvarNameChar", value); }
+		set { Schema.SetStringBytes(this.Handle, "CTriggerSndSosOpvar", "m_opvarNameChar", value, 256); }
 	}
 
 	// m_stackNameChar
@@ -83,7 +83,7 @@ public partial class CTriggerSndSosOpvar : CBaseTrigger
 	public string StackNameChar
 	{
 		get { return Schema.GetString(this.Handle, "CTriggerSndSosOpvar", "m_stackNameChar"); }
-		set { Schema.SetString(this.Handle, "CTriggerSndSosOpvar", "m_stackNameChar", value); }
+		set { Schema.SetStringBytes(this.Handle, "CTriggerSndSosOpvar", "m_stackNameChar", value, 256); }
 	}
 
 	// m_operatorNameChar
@@ -91,7 +91,7 @@ public partial class CTriggerSndSosOpvar : CBaseTrigger
 	public string OperatorNameChar
 	{
 		get { return Schema.GetString(this.Handle, "CTriggerSndSosOpvar", "m_operatorNameChar"); }
-		set { Schema.SetString(this.Handle, "CTriggerSndSosOpvar", "m_operatorNameChar", value); }
+		set { Schema.SetStringBytes(this.Handle, "CTriggerSndSosOpvar", "m_operatorNameChar", value, 256); }
 	}
 
 	// m_VecNormPos

--- a/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
@@ -173,6 +173,8 @@ public class Schema
         {
             Unsafe.Write((void*)(handle.ToInt64() + i), bytes[i]);
         }
+        
+        Unsafe.Write((void*)(handle.ToInt64() + bytes.Length), 0);
     }
     
     public static T GetCustomMarshalledType<T>(IntPtr pointer, string className, string memberName)

--- a/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using CounterStrikeSharp.API.Core;
 
 namespace CounterStrikeSharp.API.Modules.Memory;
@@ -150,13 +151,30 @@ public class Schema
     {
         return Utilities.ReadStringUtf8(pointer + GetSchemaOffset(className, memberName));
     }
-
-    public static void SetString(IntPtr pointer, string className, string memberName, string value)
+    
+    // Used to write to `string_t` and `char*` pointer type strings
+    public unsafe static void SetString(IntPtr pointer, string className, string memberName, string value)
     {
         SetSchemaValue(pointer, className, memberName, value);
     }
     
-   
+    // Used to write to the char[] specified at the schema location, i.e. char m_iszPlayerName[128]; 
+    internal unsafe static void SetStringBytes(IntPtr pointer, string className, string memberName, string value, int maxLength)
+    {
+        var handle = GetSchemaValue<IntPtr>(pointer, className, memberName);
+        
+        var bytes = Encoding.UTF8.GetBytes(value);
+        if (bytes.Length > maxLength)
+        {
+            throw new ArgumentException($"String length exceeds maximum length of {maxLength}");
+        }
+        
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            Unsafe.Write((void*)(handle.ToInt64() + i), bytes[i]);
+        }
+    }
+    
     public static T GetCustomMarshalledType<T>(IntPtr pointer, string className, string memberName)
     {
         var type = typeof(T);

--- a/managed/CounterStrikeSharp.SchemaGen/Program.cs
+++ b/managed/CounterStrikeSharp.SchemaGen/Program.cs
@@ -278,11 +278,24 @@ internal static partial class Program
             builder.AppendLine($"\t// {field.Name}");
             builder.AppendLine($"\t[SchemaMember(\"{schemaClassName}\", \"{field.Name}\")]");
 
-            if (field.Type is { Category: SchemaTypeCategory.FixedArray, CsTypeName: "string" } or
-                { Category: SchemaTypeCategory.Ptr, CsTypeName: "string" })
+            if (field.Type is { Category: SchemaTypeCategory.Ptr, CsTypeName: "string" })
             {
                 var getter = $"return Schema.GetString({handleParams});";
-                var setter = $"Schema.SetString({handleParams}, value);";
+                var setter = $"Schema.SetString({handleParams}, value{(field.Type.ArraySize != null ? ", " + field.Type.ArraySize : "")});";
+                builder.AppendLine(
+                    $"\tpublic {SanitiseTypeName(field.Type.CsTypeName)} {schemaClass.CsPropertyNameForField(schemaClassName, field)}");
+                builder.AppendLine($"\t{{");
+                builder.AppendLine(
+                    $"\t\tget {{ {getter} }}");
+                builder.AppendLine(
+                    $"\t\tset {{ {setter} }}");
+                builder.AppendLine($"\t}}");
+                builder.AppendLine();
+            }
+            if (field.Type is { Category: SchemaTypeCategory.FixedArray, CsTypeName: "string" })
+            {
+                var getter = $"return Schema.GetString({handleParams});";
+                var setter = $"Schema.SetStringBytes({handleParams}, value, {field.Type.ArraySize});";
                 builder.AppendLine(
                     $"\tpublic {SanitiseTypeName(field.Type.CsTypeName)} {schemaClass.CsPropertyNameForField(schemaClassName, field)}");
                 builder.AppendLine($"\t{{");


### PR DESCRIPTION
Properly handles string Schema property setters that are using simple char arrays, e.g. `char m_iszPlayerName[128]`

Fixes #45