### PR TITLE
feat: add chat color method for player controller

### DIFF
--- a/managed/CounterStrikeSharp.API/Modules/Extensions/PlayerExtensions.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Extensions/PlayerExtensions.cs
@@ -1,0 +1,14 @@
+﻿using CounterStrikeSharp.API.Modules.Utils;
+
+namespace CounterStrikeSharp.API.Modules.Extensions;
+
+public static class PlayerExtensions
+{
+    /// <summary>
+    /// <inheritdoc cref="ChatColors.ForPlayer"/>
+    /// </summary>
+    public static char GetChatColor(this CCSPlayerController player)
+    {
+        return ChatColors.ForPlayer(player);
+    }
+}

--- a/managed/CounterStrikeSharp.API/Modules/Extensions/TeamExtensions.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Extensions/TeamExtensions.cs
@@ -1,0 +1,15 @@
+﻿using CounterStrikeSharp.API.Modules.Utils;
+
+namespace CounterStrikeSharp.API.Modules.Extensions;
+
+public static class TeamExtensions
+{
+    /// <summary>
+    /// <inheritdoc cref="ChatColors.ForTeam"/>
+    /// </summary>
+    /// <returns></returns>
+    public static char GetChatColor(this CsTeam team)
+    {
+        return ChatColors.ForTeam(team);
+    }
+}

--- a/managed/CounterStrikeSharp.API/Modules/Utils/ChatColors.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Utils/ChatColors.cs
@@ -42,4 +42,26 @@ public class ChatColors
 
     [Obsolete("Use ChatColors.DarkRed instead.")]
     public static char Darkred = '\x02';
+
+    /// <summary>
+    /// Returns a chat color for a player based on their team.
+    /// <remarks>Blue for CT, Yellow for T, LightPurple for Spectator</remarks>
+    /// </summary>
+    /// <exception cref="Exception"></exception>
+    public static char ForPlayer(CCSPlayerController player)
+    {
+        switch (player.Team)
+        {
+            case CsTeam.None:
+                return ChatColors.White;
+            case CsTeam.Spectator:
+                return ChatColors.LightPurple;
+            case CsTeam.CounterTerrorist:
+                return ChatColors.LightBlue;
+            case CsTeam.Terrorist:
+                return ChatColors.Yellow;
+            default:
+                throw new Exception("Invalid color.");
+        }
+    }
 }

--- a/managed/CounterStrikeSharp.API/Modules/Utils/ChatColors.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Utils/ChatColors.cs
@@ -43,6 +43,29 @@ public class ChatColors
     [Obsolete("Use ChatColors.DarkRed instead.")]
     public static char Darkred = '\x02';
 
+    
+    /// <summary>
+    /// Returns a chat color based on a team.
+    /// <remarks>Blue for CT, Yellow for T, LightPurple for Spectator</remarks>
+    /// </summary>
+    /// <exception cref="Exception"></exception>
+    public static char ForTeam(CsTeam team)
+    {
+        switch (team)
+        {
+            case CsTeam.None:
+                return White;
+            case CsTeam.Spectator:
+                return LightPurple;
+            case CsTeam.CounterTerrorist:
+                return LightBlue;
+            case CsTeam.Terrorist:
+                return Yellow;
+            default:
+                throw new ArgumentException($"Invalid team: ${team}");
+        }
+    }
+
     /// <summary>
     /// Returns a chat color for a player based on their team.
     /// <remarks>Blue for CT, Yellow for T, LightPurple for Spectator</remarks>
@@ -50,18 +73,6 @@ public class ChatColors
     /// <exception cref="Exception"></exception>
     public static char ForPlayer(CCSPlayerController player)
     {
-        switch (player.Team)
-        {
-            case CsTeam.None:
-                return ChatColors.White;
-            case CsTeam.Spectator:
-                return ChatColors.LightPurple;
-            case CsTeam.CounterTerrorist:
-                return ChatColors.LightBlue;
-            case CsTeam.Terrorist:
-                return ChatColors.Yellow;
-            default:
-                throw new Exception("Invalid color.");
-        }
+        return ForTeam(player.Team);
     }
 }


### PR DESCRIPTION
Adds new method & extension methods, credit to @busheezy for fetching a players chat color.

`ChatColors.ForPlayer(player);`
`player.GetChatColor();`
`player.Team.GetChatColor();`

Closes #161