### PR TITLE
feat: improve entity validation

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using CounterStrikeSharp.API.Modules.Memory;
 using CounterStrikeSharp.API.Modules.Utils;
 
@@ -6,14 +7,20 @@ namespace CounterStrikeSharp.API.Core;
 
 public partial class CBaseEntity
 {
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void Teleport(Vector position, QAngle angles, Vector velocity)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunction.CreateVoid<IntPtr, IntPtr, IntPtr, IntPtr>(Handle, GameData.GetOffset("CBaseEntity_Teleport"))(
             Handle, position.Handle, angles.Handle, velocity.Handle);
     }
 
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void DispatchSpawn()
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunctions.CBaseEntity_DispatchSpawn(Handle, IntPtr.Zero);
     }
 
@@ -25,7 +32,13 @@ public partial class CBaseEntity
     /// <summary>
     /// Shorthand for accessing an entity's CBodyComponent?.SceneNode?.AbsRotation;
     /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public QAngle? AbsRotation => CBodyComponent?.SceneNode?.AbsRotation;
 
-    public T? GetVData<T>() where T : CEntitySubclassVDataBase => (T)Activator.CreateInstance(typeof(T),  Marshal.ReadIntPtr(SubclassID.Handle + 4));
+    public T? GetVData<T>() where T : CEntitySubclassVDataBase
+    {
+        Guard.IsValidEntity(this);
+
+        return (T) Activator.CreateInstance(typeof(T), Marshal.ReadIntPtr(SubclassID.Handle + 4));
+    }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CBaseModelEntity.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBaseModelEntity.cs
@@ -20,8 +20,11 @@ namespace CounterStrikeSharp.API.Core;
 
 public partial class CBaseModelEntity
 {
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void SetModel(string model)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunctions.SetModel(Handle, model);
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CBasePlayerController.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBasePlayerController.cs
@@ -1,5 +1,4 @@
 using System;
-
 using CounterStrikeSharp.API.Modules.Cvars;
 using CounterStrikeSharp.API.Modules.Entities;
 using CounterStrikeSharp.API.Modules.Entities.Constants;
@@ -10,10 +9,13 @@ namespace CounterStrikeSharp.API.Core;
 
 public partial class CBasePlayerController
 {
-	public void SetPawn(CBasePlayerPawn? pawn)
-	{
-		if (pawn is null) return;
-		if (!pawn.IsValid) return;
-		VirtualFunctions.CBasePlayerController_SetPawnFunc.Invoke(this, pawn, true, false);
-	}
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
+    public void SetPawn(CBasePlayerPawn? pawn)
+    {
+        Guard.IsValidEntity(this);
+
+        if (pawn is null) return;
+        if (!pawn.IsValid) return;
+        VirtualFunctions.CBasePlayerController_SetPawnFunc.Invoke(this, pawn, true, false);
+    }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CBasePlayerPawn.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBasePlayerPawn.cs
@@ -10,17 +10,24 @@ public partial class CBasePlayerPawn
     /// </summary>
     /// <param name="explode"></param>
     /// <param name="force"></param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void CommitSuicide(bool explode, bool force)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunction.CreateVoid<IntPtr, bool, bool>(Handle,  GameData.GetOffset("CBasePlayerPawn_CommitSuicide"))(Handle, explode, force);
     }
-    
+
     /// <summary>
     /// Remove Player Item
     /// </summary>
     /// <param name="weapon"></param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void RemovePlayerItem(CBasePlayerWeapon weapon)
     {
+        Guard.IsValidEntity(this);
+        Guard.IsValidEntity(weapon);
+
         VirtualFunctions.RemovePlayerItemVirtual(Handle, weapon.Handle);
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
@@ -13,8 +13,11 @@ public partial class CCSPlayerController
     public int? UserId => NativeAPI.GetUseridFromIndex((int)Index);
     public CsTeam Team => (CsTeam)TeamNum;
 
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public IntPtr GiveNamedItem(string item)
     {
+        Guard.IsValidEntity(this);
+
         if (!PlayerPawn.IsValid) return 0;
         if (PlayerPawn.Value == null) return 0;
         if (!PlayerPawn.Value.IsValid) return 0;
@@ -34,25 +37,37 @@ public partial class CCSPlayerController
         return GiveNamedItem(itemString);
     }
 
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void PrintToConsole(string message)
     {
+        Guard.IsValidEntity(this);
+
         NativeAPI.PrintToConsole((int)Index, $"{message}\n\0");
     }
 
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void PrintToChat(string message)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunctions.ClientPrint(Handle, HudDestination.Chat, message, 0, 0, 0, 0);
     }
 
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void PrintToCenter(string message)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunctions.ClientPrint(Handle, HudDestination.Center, message, 0, 0, 0, 0);
     }
 
     public void PrintToCenterHtml(string message) => PrintToCenterHtml(message, 5);
-    
+
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void PrintToCenterHtml(string message, int duration)
     {
+        Guard.IsValidEntity(this);
+
         var @event = new EventShowSurvivalRespawnStatus(true)
         {
             LocToken = message,
@@ -65,8 +80,10 @@ public partial class CCSPlayerController
     /// <summary>
     /// Drops the active player weapon on the ground.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void DropActiveWeapon()
     {
+        Guard.IsValidEntity(this);
         if (!PlayerPawn.IsValid) return;
         if (PlayerPawn.Value == null) return;
         if (!PlayerPawn.Value.IsValid) return;
@@ -83,8 +100,10 @@ public partial class CCSPlayerController
     /// <summary>
     /// Removes every weapon from the player.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void RemoveWeapons()
     {
+        Guard.IsValidEntity(this);
         if (!PlayerPawn.IsValid) return;
         if (PlayerPawn.Value == null) return;
         if (!PlayerPawn.Value.IsValid) return;
@@ -99,8 +118,10 @@ public partial class CCSPlayerController
     /// </summary>
     /// <param name="explode"></param>
     /// <param name="force"></param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void CommitSuicide(bool explode, bool force)
     {
+        Guard.IsValidEntity(this);
         if (!PlayerPawn.IsValid) return;
         if (PlayerPawn.Value == null) return;
         if (!PlayerPawn.Value.IsValid) return;
@@ -111,8 +132,10 @@ public partial class CCSPlayerController
     /// <summary>
     /// Respawn player
     /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void Respawn()
     {
+        Guard.IsValidEntity(this);
         if (!PlayerPawn.IsValid) return;
         if (PlayerPawn.Value == null) return;
         if (!PlayerPawn.Value.IsValid) return;
@@ -128,8 +151,11 @@ public partial class CCSPlayerController
     /// Forcibly switches the team of the player, the player will remain alive and keep their weapons.
     /// </summary>
     /// <param name="team">The team to switch to</param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void SwitchTeam(CsTeam team)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunctions.SwitchTeam(Handle, (byte)team);
     }
 
@@ -140,8 +166,11 @@ public partial class CCSPlayerController
     /// </remarks>
     /// </summary>
     /// <param name="team">The team to change to</param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void ChangeTeam(CsTeam team)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunction.CreateVoid<IntPtr, CsTeam>(Handle, GameData.GetOffset("CCSPlayerController_ChangeTeam"))(Handle,
             team);
     }
@@ -151,8 +180,11 @@ public partial class CCSPlayerController
     /// </summary>
     /// <param name="conVar">Name of the convar to retrieve</param>
     /// <returns>ConVar string value</returns>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public string GetConVarValue(string conVar)
     {
+        Guard.IsValidEntity(this);
+
         return NativeAPI.GetClientConvarValue(Slot, conVar);
     }
 
@@ -171,13 +203,12 @@ public partial class CCSPlayerController
     /// </summary>
     /// <param name="conVar">Console variable name</param>
     /// <param name="value">String value to set</param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     /// <exception cref="InvalidOperationException">Player is not a bot</exception>
     public void SetFakeClientConVar(string conVar, string value)
     {
-        if (!IsBot)
-        {
-            throw new InvalidOperationException("'SetFakeClientConVar' can only be called for fake clients (bots)");
-        }
+        Guard.IsValidEntity(this);
+        if (!IsBot) throw new InvalidOperationException("'SetFakeClientConVar' can only be called for fake clients (bots)");
 
         NativeAPI.SetFakeClientConvarValue(Slot, conVar, value);
     }
@@ -207,27 +238,45 @@ public partial class CCSPlayerController
     /// Note: Only works for some commands, marked with the FCVAR_CLIENT_CAN_EXECUTE flag (not many).
     /// </summary>
     /// <param name="command"></param>
-    public void ExecuteClientCommand(string command) => NativeAPI.IssueClientCommand(Slot, command);
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
+    public void ExecuteClientCommand(string command)
+    {
+        Guard.IsValidEntity(this);
+
+        NativeAPI.IssueClientCommand(Slot, command);
+    }
 
     /// <summary>
     /// Issue the specified command directly from the server (mimics the server executing the command with the given player context).
     /// <remarks>Works with server commands like `kill`, `explode`, `noclip`, etc. </remarks>
     /// </summary>
     /// <param name="command"></param>
-    public void ExecuteClientCommandFromServer(string command) => NativeAPI.IssueClientCommandFromServer(Slot, command);
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
+    public void ExecuteClientCommandFromServer(string command)
+    {
+        Guard.IsValidEntity(this);
+
+        NativeAPI.IssueClientCommandFromServer(Slot, command);
+    }
 
     /// <summary>
     /// Overrides who a player can hear in voice chat.
     /// </summary>
     /// <param name="sender">Player talking in the voice chat</param>
     /// <param name="override">Whether the talker should be heard</param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void SetListenOverride(CCSPlayerController sender, ListenOverride @override)
     {
+        Guard.IsValidEntity(this);
+
         NativeAPI.SetClientListening(Handle, sender.Handle, (Byte)@override);
     }
-    
+
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public ListenOverride GetListenOverride(CCSPlayerController sender)
     {
+        Guard.IsValidEntity(this);
+
         return NativeAPI.GetClientListening(Handle, sender.Handle);
     }
 
@@ -236,27 +285,31 @@ public partial class CCSPlayerController
     /// <summary>
     /// Returns the authorized SteamID of this user which has been validated with the SteamAPI.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public SteamID? AuthorizedSteamID
     {
         get
         {
-            if (!IsValid) return null;
+            Guard.IsValidEntity(this);
+
             var authorizedSteamId = NativeAPI.GetPlayerAuthorizedSteamid(Slot);
             if ((long)authorizedSteamId == -1) return null;
 
             return (SteamID)authorizedSteamId;
         }
     }
-    
+
     /// <summary>
     /// Returns the IP address (and possibly port) of this player.
     /// <remarks>Returns 127.0.0.1 if the player is a bot.</remarks>
     /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public string? IpAddress
     {
         get
         {
-            if (!IsValid) return null;
+            Guard.IsValidEntity(this);
+
             var ipAddress = NativeAPI.GetPlayerIpAddress(Slot);
             if (string.IsNullOrWhiteSpace(ipAddress)) return null;
 
@@ -267,9 +320,20 @@ public partial class CCSPlayerController
     /// <summary>
     /// Determines how the player interacts with voice chat.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public VoiceFlags VoiceFlags
     {
-        get => (VoiceFlags)NativeAPI.GetClientVoiceFlags(Handle);
-        set => NativeAPI.SetClientVoiceFlags(Handle, (Byte)value);
+        get
+        {
+            Guard.IsValidEntity(this);
+
+            return (VoiceFlags)NativeAPI.GetClientVoiceFlags(Handle);
+        }
+        set
+        {
+            Guard.IsValidEntity(this);
+
+            NativeAPI.SetClientVoiceFlags(Handle, (Byte)value);
+        }
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
@@ -23,16 +23,26 @@ public partial class CCSPlayer_ItemServices
     /// <summary>
     /// Drops the active player weapon on the ground.
     /// </summary>
+    /// <exception cref="InvalidOperationException">ItemServices points to null</exception>
     public void DropActivePlayerWeapon(CBasePlayerWeapon activeWeapon)
     {
+        if(Handle == IntPtr.Zero)
+            throw new InvalidOperationException("ItemServices points to null.");
+
+        Guard.IsValidEntity(activeWeapon);
+
         VirtualFunction.CreateVoid<nint, nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_DropActivePlayerWeapon"))(Handle, activeWeapon.Handle);
     }
-    
+
     /// <summary>
     /// Removes every weapon from the player.
     /// </summary>
+    /// <exception cref="InvalidOperationException">ItemServices points to null</exception>
     public void RemoveWeapons()
     {
+        if (Handle == IntPtr.Zero)
+            throw new InvalidOperationException("ItemServices points to null.");
+
         VirtualFunction.CreateVoid<nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_RemoveWeapons"))(Handle);
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CEntityInstance.cs
@@ -32,7 +32,12 @@ public partial class CEntityInstance : IEquatable<CEntityInstance>
     
     public string DesignerName => IsValid ? Entity?.DesignerName : null;
 
-    public void Remove() => VirtualFunctions.UTIL_Remove(this.Handle);
+    public void Remove()
+    {
+        Guard.IsValidEntity(this);
+
+        VirtualFunctions.UTIL_Remove(this.Handle);
+    }
     
     public bool Equals(CEntityInstance? other)
     {
@@ -58,7 +63,7 @@ public partial class CEntityInstance : IEquatable<CEntityInstance>
     {
         return !Equals(left, right);
     }
-    
+
     /// <summary>
     /// Calls a named input method on an entity.
     /// <example>
@@ -72,8 +77,11 @@ public partial class CEntityInstance : IEquatable<CEntityInstance>
     /// <param name="caller">Entity that is sending the event, <see langword="null"/> for no entity</param>
     /// <param name="value">String variant value to send with the event</param>
     /// <param name="outputId">Unknown, defaults to 0</param>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public void AcceptInput(string inputName, CEntityInstance? activator = null, CEntityInstance? caller = null, string value = "", int outputId = 0)
     {
+        Guard.IsValidEntity(this);
+
         VirtualFunctions.AcceptInput(Handle, inputName, activator?.Handle ?? IntPtr.Zero, caller?.Handle ?? IntPtr.Zero, value, 0);
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CGameSceneNode.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CGameSceneNode.cs
@@ -23,8 +23,11 @@ public partial class CGameSceneNode
     /// <summary>
     /// Gets the <see cref="CSkeletonInstance"/> instance from the node.
     /// </summary>
+    /// <exception cref="InvalidOperationException">GameSceneNode points to null</exception>
     public CSkeletonInstance GetSkeletonInstance()
     {
+        if (Handle == IntPtr.Zero) throw new InvalidOperationException("GameSceneNode points to null.");
+
         return new CSkeletonInstance(VirtualFunction.Create<nint, nint>(Handle, GameData.GetOffset("CGameSceneNode_GetSkeletonInstance"))(Handle));
     }
 }

--- a/managed/CounterStrikeSharp.API/Guard.cs
+++ b/managed/CounterStrikeSharp.API/Guard.cs
@@ -1,0 +1,11 @@
+﻿namespace CounterStrikeSharp.API
+{
+    public static class Guard
+    {
+        public static void IsValidEntity(CEntityInstance ent)
+        {
+            if (!ent.IsValid)
+                throw new InvalidOperationException("Entity is not valid");
+        }
+    }
+}

--- a/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -78,11 +79,15 @@ public class Schema
 
     public static T GetSchemaValue<T>(IntPtr handle, string className, string propertyName)
     {
+        if (handle == IntPtr.Zero) throw new ArgumentNullException(nameof(handle), "Schema target points to null.");
+
         return NativeAPI.GetSchemaValueByName<T>(handle, (int)typeof(T).ToDataType(), className, propertyName);
     }
 
     public static void SetSchemaValue<T>(IntPtr handle, string className, string propertyName, T value)
     {
+        if (handle == IntPtr.Zero) throw new ArgumentNullException(nameof(handle), "Schema target points to null.");
+
         if (CoreConfig.FollowCS2ServerGuidelines && _cs2BadList.Contains(propertyName))
         {
             throw new Exception($"Cannot set or get '{className}::{propertyName}' with \"FollowCS2ServerGuidelines\" option enabled.");
@@ -93,11 +98,15 @@ public class Schema
 
     public static T GetDeclaredClass<T>(IntPtr pointer, string className, string memberName)
     {
+        if (pointer == IntPtr.Zero) throw new ArgumentNullException(nameof(pointer), "Schema target points to null.");
+
         return (T)Activator.CreateInstance(typeof(T), pointer + GetSchemaOffset(className, memberName));
     }
 
     public static unsafe ref T GetRef<T>(IntPtr pointer, string className, string memberName)
     {
+        if (pointer == IntPtr.Zero) throw new ArgumentNullException(nameof(pointer), "Schema target points to null.");
+
         return ref Unsafe.AsRef<T>((void*)(pointer + GetSchemaOffset(className, memberName)));
     }
 
@@ -114,6 +123,8 @@ public class Schema
 
     public static T GetPointer<T>(IntPtr pointer, string className, string memberName)
     {
+        if (pointer == IntPtr.Zero) throw new ArgumentNullException(nameof(pointer), "Schema target points to null.");
+
         var pointerTo = Marshal.ReadIntPtr(pointer + GetSchemaOffset(className, memberName));
         if (pointerTo == IntPtr.Zero)
         {
@@ -125,6 +136,8 @@ public class Schema
 
     public static unsafe Span<T> GetFixedArray<T>(IntPtr pointer, string className, string memberName, int count)
     {
+        if (pointer == IntPtr.Zero) throw new ArgumentNullException(nameof(pointer), "Schema target points to null.");
+
         Span<T> span = new((void*)(pointer + GetSchemaOffset(className, memberName)), count);
         return span;
     }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -209,8 +209,11 @@ namespace CounterStrikeSharp.API
         /// <param name="className" example="CBaseEntity">Schema field class name</param>
         /// <param name="fieldName" example="m_iHealth">Schema field name</param>
         /// <param name="extraOffset">Any additional offset to the schema field</param>
+        /// <exception cref="InvalidOperationException">Entity is not valid</exception>
         public static void SetStateChanged(CBaseEntity entity, string className, string fieldName, int extraOffset = 0)
         {
+            Guard.IsValidEntity(entity);
+
             if (!Schema.IsSchemaFieldNetworked(className, fieldName))
             {
                 Application.Instance.Logger.LogWarning("Field {ClassName}:{FieldName} is not networked, but SetStateChanged was called on it.", className, fieldName);

--- a/src/scripting/natives/natives_entities.cpp
+++ b/src/scripting/natives/natives_entities.cpp
@@ -29,6 +29,12 @@
 namespace counterstrikesharp {
 
 CBaseEntity* GetEntityFromIndex(ScriptContext& script_context) {
+    if (!globals::entitySystem)
+    {
+        script_context.ThrowNativeError("Entity system is not yet initialized");
+        return nullptr;
+    }
+
     auto entityIndex = script_context.GetArgument<int>(0);
 
     return globals::entitySystem->GetBaseEntity(CEntityIndex(entityIndex));
@@ -47,6 +53,11 @@ const char* GetDesignerName(ScriptContext& scriptContext) {
 }
 
 void* GetEntityPointerFromHandle(ScriptContext& scriptContext) {
+    if (!globals::entitySystem) {
+        scriptContext.ThrowNativeError("Entity system is not yet initialized");
+        return nullptr;
+    }
+
     auto handle = scriptContext.GetArgument<CEntityHandle*>(0);
 
     if (!handle->IsValid()) {
@@ -57,6 +68,11 @@ void* GetEntityPointerFromHandle(ScriptContext& scriptContext) {
 }
 
 void* GetEntityPointerFromRef(ScriptContext& scriptContext) {
+    if (!globals::entitySystem) {
+        scriptContext.ThrowNativeError("Entity system yet is not initialized");
+        return nullptr;
+    }
+
     auto ref = scriptContext.GetArgument<unsigned int>(0);
 
     if (ref == INVALID_EHANDLE_INDEX) {
@@ -87,6 +103,11 @@ unsigned int GetRefFromEntityPointer(ScriptContext& scriptContext) {
 }
 
 bool IsRefValidEntity(ScriptContext& scriptContext) {
+    if (!globals::entitySystem) {
+        scriptContext.ThrowNativeError("Entity system yet is not initialized");
+        return false;
+    }
+
     auto ref = scriptContext.GetArgument<unsigned int>(0);
 
     if (ref == INVALID_EHANDLE_INDEX) {
@@ -110,10 +131,20 @@ void PrintToConsole(ScriptContext& scriptContext) {
 }
 
 CEntityIdentity* GetFirstActiveEntity(ScriptContext& script_context) {
+    if (!globals::entitySystem) {
+        script_context.ThrowNativeError("Entity system yet is not initialized");
+        return nullptr;
+    }
+
     return globals::entitySystem->m_EntityList.m_pFirstActiveEntity;
 }
 
 void* GetConcreteEntityListPointer(ScriptContext& script_context) {
+    if (!globals::entitySystem) {
+        script_context.ThrowNativeError("Entity system yet is not initialized");
+        return nullptr;
+    }
+
     return &globals::entitySystem->m_EntityList;
 }
 


### PR DESCRIPTION
As of right now cs# isn't very strict about the values the API works with, this allows for edge cases that can lead to server crashes. This PR adds the most basic checks to prevent obviously wrong arguments.

Note for developers using cs#
Please do report code that causes unexpected crashes or memory access violations, no code exposed by cs# should ever lead to a server crash.