### PR TITLE
fix: allow using an empty flag array in overrides

### DIFF
--- a/managed/CounterStrikeSharp.API.Tests/AdminTests.cs
+++ b/managed/CounterStrikeSharp.API.Tests/AdminTests.cs
@@ -102,9 +102,18 @@ public class AdminTests
     [Fact]
     public void ShouldAddCommandPermissionOverridesAtRuntime()
     {
-        Assert.False(AdminManager.CommandIsOverriden("runtime_command"));
-        AdminManager.AddPermissionOverride("runtime_command", "@runtime/override");
-        Assert.True(AdminManager.CommandIsOverriden("runtime_command"));
-        Assert.Equal("@runtime/override", AdminManager.GetPermissionOverrides("runtime_command").Single());
+        Assert.False(AdminManager.CommandIsOverriden("runtime_command_a"));
+        AdminManager.AddPermissionOverride("runtime_command_a", "@runtime/override");
+        Assert.True(AdminManager.CommandIsOverriden("runtime_command_a"));
+        Assert.Equal("@runtime/override", AdminManager.GetPermissionOverrides("runtime_command_a").Single());
+    }
+
+    [Fact]
+    public void ShouldAddCommandPermissionOverridesWithEmpty()
+    {
+        Assert.False(AdminManager.CommandIsOverriden("runtime_command_b"));
+        AdminManager.AddPermissionOverride("runtime_command_b");
+        Assert.True(AdminManager.CommandIsOverriden("runtime_command_b"));
+        Assert.False(AdminManager.GetPermissionOverrides("runtime_command_b").Any());
     }
 }

--- a/managed/CounterStrikeSharp.API/Modules/Admin/AdminCommandOverrides.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Admin/AdminCommandOverrides.cs
@@ -62,7 +62,7 @@ namespace CounterStrikeSharp.API.Modules.Admin
         {
             CommandOverrides.TryGetValue(commandName, out var overrideDef);
             if (overrideDef == null) return false;
-            return overrideDef.Enabled && overrideDef?.Flags.Count() > 0;
+            return overrideDef.Enabled;
         }
 
         /// <summary>


### PR DESCRIPTION
This is currently preventing a valid use. If someone wants to entirely remove flag requirements of a command with overrides, they would be unable to.