### PR TITLE
feat: add `Server.RunOnTick` method which allows tick scheduling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ SET(SOURCE_FILES
     src/core/managers/event_manager.cpp
     src/core/timer_system.h
     src/core/timer_system.cpp
+    src/core/tick_scheduler.h
+    src/core/tick_scheduler.cpp
     src/scripting/autonative.h
     src/scripting/natives/natives_engine.cpp
     src/core/engine_trace.h

--- a/managed/CounterStrikeSharp.API/CompatibilitySuppressions.xml
+++ b/managed/CounterStrikeSharp.API/CompatibilitySuppressions.xml
@@ -441,6 +441,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:CounterStrikeSharp.API.Core.NativeAPI.GetGameFrameTime</Target>
+    <Left>.\ApiCompat\v151.dll</Left>
+    <Right>obj\Debug\net7.0\CounterStrikeSharp.API.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:CounterStrikeSharp.API.Core.NativeAPI.QueueTaskForNextFrame(System.IntPtr)</Target>
     <Left>.\ApiCompat\v151.dll</Left>
     <Right>obj\Debug\net7.0\CounterStrikeSharp.API.dll</Right>
@@ -466,6 +472,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:CounterStrikeSharp.API.Core.Translations.JsonStringLocalizerFactory.#ctor(CounterStrikeSharp.API.Core.Plugin.IPluginContext)</Target>
+    <Left>.\ApiCompat\v151.dll</Left>
+    <Right>obj\Debug\net7.0\CounterStrikeSharp.API.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:CounterStrikeSharp.API.Modules.Memory.DynamicFunctions.DynamicHook.GetReturn``1(System.Int32)</Target>
+    <Left>.\ApiCompat\v151.dll</Left>
+    <Right>obj\Debug\net7.0\CounterStrikeSharp.API.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:CounterStrikeSharp.API.Server.get_GameFrameTime</Target>
     <Left>.\ApiCompat\v151.dll</Left>
     <Right>obj\Debug\net7.0\CounterStrikeSharp.API.dll</Right>
   </Suppression>

--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -315,16 +315,6 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
-        public static float GetGameFrameTime(){
-			lock (ScriptContext.GlobalScriptContext.Lock) {
-			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.SetIdentifier(0x97E331CA);
-			ScriptContext.GlobalScriptContext.Invoke();
-			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
-			}
-		}
-
         public static double GetEngineTime(){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();

--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -512,6 +512,17 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+        public static void QueueTaskForFrame(int tick, InputArgument callback){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.Push(tick);
+			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x2F92C340);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
         public static void QueueTaskForNextWorldUpdate(InputArgument callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();

--- a/managed/CounterStrikeSharp.API/Server.cs
+++ b/managed/CounterStrikeSharp.API/Server.cs
@@ -28,12 +28,18 @@ namespace CounterStrikeSharp.API
 {
     public class Server
     {
+        /// <summary>
+        /// Duration of a single game tick in seconds, based on a 64 tick server (hard coded in CS2).
+        /// </summary>
         public static float TickInterval => 0.015625f;
 
+        /// <summary>
+        /// Executes a command on the server, as if it was entered from the console.
+        /// </summary>
+        /// <param name="command"></param>
         public static void ExecuteCommand(string command) => NativeAPI.IssueServerCommand(command);
 
         public static string MapName => NativeAPI.GetMapName();
-        // public static void PrintToConsole(string message) => NativeAPI.PrintToConsole(message);
 
         /// <summary>
         /// Returns the total time the server has been running in seconds.

--- a/managed/CounterStrikeSharp.API/Server.cs
+++ b/managed/CounterStrikeSharp.API/Server.cs
@@ -69,12 +69,9 @@ namespace CounterStrikeSharp.API
         /// See <see cref="TickCount"/> to retrieve the current tick.
         /// <remarks>Does not execute if the server is hibernating.</remarks>
         /// </summary>
-        public static Task RunOnTick(int tick, Action task)
+        public static void RunOnTick(int tick, Action task)
         {
             RunOnTickAsync(tick, task);
-            var functionReference = FunctionReference.Create(task, FunctionLifetime.SingleUse);
-            NativeAPI.QueueTaskForFrame(tick, functionReference);
-            return functionReference.CompletionTask;
         }
 
         /// <summary>

--- a/managed/CounterStrikeSharp.API/Server.cs
+++ b/managed/CounterStrikeSharp.API/Server.cs
@@ -49,8 +49,7 @@ namespace CounterStrikeSharp.API
         public static float CurrentTime => NativeAPI.GetCurrentTime();
         
         /// <summary>
-        /// Returns the current tick count.
-        /// This value is incremented every frame, but only when the server is not hibernating.
+        /// Returns the current map tick count.
         /// CS2 is a 64 tick server, so the value will increment by 64 every second.
         /// </summary>
         public static int TickCount => NativeAPI.GetTickCount();

--- a/managed/CounterStrikeSharp.API/Server.cs
+++ b/managed/CounterStrikeSharp.API/Server.cs
@@ -35,12 +35,17 @@ namespace CounterStrikeSharp.API
         public static string MapName => NativeAPI.GetMapName();
         // public static void PrintToConsole(string message) => NativeAPI.PrintToConsole(message);
 
+        /// <summary>
+        /// Returns the total time the server has been running in seconds.
+        /// </summary>
+        /// <remarks>Does not increment when server is hibernating</remarks>
         public static double TickedTime => NativeAPI.GetTickedTime();
         
         /// <summary>
-        /// Returns the current time in seconds, as an interval of the server's tick interval.
-        /// e.g. 70.046875 would represent 70 seconds of uptime and the 4483rd tick of the server (70.046875 / 0.015625).
+        /// Returns the current map time in seconds, as an interval of the server's tick interval.
+        /// e.g. 70.046875 would represent 70 seconds of map time and the 4483rd tick of the server (70.046875 / 0.015625).
         /// </summary>
+        /// <remarks>Increments even when server is hibernating</remarks>
         public static float CurrentTime => NativeAPI.GetCurrentTime();
         
         /// <summary>
@@ -49,8 +54,13 @@ namespace CounterStrikeSharp.API
         /// CS2 is a 64 tick server, so the value will increment by 64 every second.
         /// </summary>
         public static int TickCount => NativeAPI.GetTickCount();
-        public static float GameFrameTime => NativeAPI.GetGameFrameTime();
+        
+        /// <summary>
+        /// Returns the total time the server has been running in seconds.
+        /// </summary>
+        /// <remarks>Increments even when server is hibernating</remarks>
         public static double EngineTime => NativeAPI.GetEngineTime();
+        
         public static void PrecacheModel(string name) => NativeAPI.PrecacheModel(name);
         
         /// <summary>

--- a/managed/CounterStrikeSharp.API/Server.cs
+++ b/managed/CounterStrikeSharp.API/Server.cs
@@ -28,7 +28,7 @@ namespace CounterStrikeSharp.API
 {
     public class Server
     {
-        public static float TickInterval => NativeAPI.GetTickInterval();
+        public static float TickInterval => 0.015625f;
 
         public static void ExecuteCommand(string command) => NativeAPI.IssueServerCommand(command);
 
@@ -36,11 +36,46 @@ namespace CounterStrikeSharp.API
         // public static void PrintToConsole(string message) => NativeAPI.PrintToConsole(message);
 
         public static double TickedTime => NativeAPI.GetTickedTime();
+        
+        /// <summary>
+        /// Returns the current time in seconds, as an interval of the server's tick interval.
+        /// e.g. 70.046875 would represent 70 seconds of uptime and the 4483rd tick of the server (70.046875 / 0.015625).
+        /// </summary>
         public static float CurrentTime => NativeAPI.GetCurrentTime();
+        
+        /// <summary>
+        /// Returns the current tick count.
+        /// This value is incremented every frame, but only when the server is not hibernating.
+        /// CS2 is a 64 tick server, so the value will increment by 64 every second.
+        /// </summary>
         public static int TickCount => NativeAPI.GetTickCount();
         public static float GameFrameTime => NativeAPI.GetGameFrameTime();
         public static double EngineTime => NativeAPI.GetEngineTime();
         public static void PrecacheModel(string name) => NativeAPI.PrecacheModel(name);
+        
+        /// <summary>
+        /// <inheritdoc cref="RunOnTick"/>
+        /// Returns Task that completes once the synchronous task has been completed.
+        /// </summary>
+        public static Task RunOnTickAsync(int tick, Action task)
+        {
+            var functionReference = FunctionReference.Create(task, FunctionLifetime.SingleUse);
+            NativeAPI.QueueTaskForFrame(tick, functionReference);
+            return functionReference.CompletionTask;
+        }
+        
+        /// <summary>
+        /// Queue a task to be executed on the specified tick.
+        /// See <see cref="TickCount"/> to retrieve the current tick.
+        /// <remarks>Does not execute if the server is hibernating.</remarks>
+        /// </summary>
+        public static Task RunOnTick(int tick, Action task)
+        {
+            RunOnTickAsync(tick, task);
+            var functionReference = FunctionReference.Create(task, FunctionLifetime.SingleUse);
+            NativeAPI.QueueTaskForFrame(tick, functionReference);
+            return functionReference.CompletionTask;
+        }
 
         /// <summary>
         /// <inheritdoc cref="NextFrame"/>

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -1,6 +1,7 @@
 #include "mm_plugin.h"
 #include "core/globals.h"
 #include "core/managers/player_manager.h"
+#include "core/tick_scheduler.h"
 #include "iserver.h"
 #include "managers/event_manager.h"
 #include "scripting/callback_manager.h"
@@ -79,6 +80,7 @@ EntityManager entityManager;
 ChatManager chatManager;
 ServerManager serverManager;
 VoiceManager voiceManager;
+TickScheduler tickScheduler;
 
 bool gameLoopInitialized = false;
 GetLegacyGameEventListener_t* GetLegacyGameEventListener = nullptr;

--- a/src/core/globals.h
+++ b/src/core/globals.h
@@ -47,6 +47,7 @@ class CallbackManager;
 class ConVarManager;
 class PlayerManager;
 class MenuManager;
+class TickScheduler;
 class TimerSystem;
 class ChatCommands;
 class HookManager;
@@ -100,6 +101,7 @@ extern ChatCommands chatCommands;
 extern ChatManager chatManager;
 extern ServerManager serverManager;
 extern VoiceManager voiceManager;
+extern TickScheduler tickScheduler;
 
 extern HookManager hookManager;
 extern SourceHook::ISourceHook *source_hook;

--- a/src/core/tick_scheduler.cpp
+++ b/src/core/tick_scheduler.cpp
@@ -1,0 +1,45 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
+ */
+
+#include "tick_scheduler.h"
+
+namespace counterstrikesharp {
+
+void TickScheduler::schedule(int tick, std::function<void()> callback)
+{
+    std::lock_guard<std::mutex> lock(taskMutex);
+    scheduledTasks.push(std::make_pair(tick, callback));
+}
+
+std::vector<std::function<void()>> TickScheduler::getCallbacks(int currentTick)
+{
+    std::vector<std::function<void()>> callbacksToRun;
+
+    std::lock_guard<std::mutex> lock(taskMutex);
+
+    if (scheduledTasks.empty()) {
+        return callbacksToRun;
+    }
+
+    // Process tasks due for the current tick
+    while (!scheduledTasks.empty() && scheduledTasks.top().first <= currentTick) {
+        callbacksToRun.push_back(scheduledTasks.top().second);
+        scheduledTasks.pop();
+    }
+
+    return callbacksToRun;
+}
+} // namespace counterstrikesharp

--- a/src/core/tick_scheduler.h
+++ b/src/core/tick_scheduler.h
@@ -1,0 +1,44 @@
+/*
+*  This file is part of CounterStrikeSharp.
+*  CounterStrikeSharp is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  CounterStrikeSharp is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
+*/
+
+#include <functional>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+namespace counterstrikesharp {
+class TickScheduler
+{
+ public:
+   struct TaskComparator
+   {
+       bool operator()(const std::pair<int, std::function<void()>>& a,
+                       const std::pair<int, std::function<void()>>& b) const
+       {
+           return a.first > b.first;
+       }
+   };
+
+   void schedule(int tick, std::function<void()> callback);
+   std::vector<std::function<void()>> getCallbacks(int currentTick);
+ private:
+   std::priority_queue<std::pair<int, std::function<void()>>,
+                       std::vector<std::pair<int, std::function<void()>>>,
+                       TaskComparator>
+       scheduledTasks;
+   std::mutex taskMutex;
+};
+} // namespace counterstrikesharp

--- a/src/scripting/natives/natives_engine.cpp
+++ b/src/scripting/natives/natives_engine.cpp
@@ -32,6 +32,7 @@
 #include "core/function.h"
 #include "core/managers/player_manager.h"
 #include "core/managers/server_manager.h"
+#include "core/tick_scheduler.h"
 // clang-format on
 
 #if _WIN32
@@ -238,6 +239,15 @@ void QueueTaskForNextWorldUpdate(ScriptContext& script_context)
     globals::serverManager.AddTaskForNextWorldUpdate([func]() { reinterpret_cast<voidfunc*>(func)(); });
 }
 
+void QueueTaskForFrame(ScriptContext& script_context)
+{
+    auto tick = script_context.GetArgument<int>(0);
+    auto func = script_context.GetArgument<void*>(1);
+
+    typedef void(voidfunc)(void);
+    globals::tickScheduler.schedule(tick, reinterpret_cast<voidfunc*>(func));
+}
+
 enum InterfaceType
 {
     Engine,
@@ -331,6 +341,7 @@ REGISTER_NATIVES(engine, {
     ScriptEngine::RegisterNativeHandler("GET_TICKED_TIME", GetTickedTime);
     ScriptEngine::RegisterNativeHandler("QUEUE_TASK_FOR_NEXT_FRAME", QueueTaskForNextFrame);
     ScriptEngine::RegisterNativeHandler("QUEUE_TASK_FOR_NEXT_WORLD_UPDATE", QueueTaskForNextWorldUpdate);
+    ScriptEngine::RegisterNativeHandler("QUEUE_TASK_FOR_FRAME", QueueTaskForFrame);
     ScriptEngine::RegisterNativeHandler("GET_VALVE_INTERFACE", GetValveInterface);
     ScriptEngine::RegisterNativeHandler("GET_COMMAND_PARAM_VALUE", GetCommandParamValue);
     ScriptEngine::RegisterNativeHandler("PRINT_TO_SERVER_CONSOLE", PrintToServerConsole);

--- a/src/scripting/natives/natives_engine.yaml
+++ b/src/scripting/natives/natives_engine.yaml
@@ -4,7 +4,6 @@ IS_MAP_VALID: mapname:string -> bool
 GET_TICK_INTERVAL: -> float
 GET_CURRENT_TIME: -> float
 GET_TICK_COUNT: -> int
-GET_GAME_FRAME_TIME: -> float
 GET_ENGINE_TIME: -> double
 GET_MAX_CLIENTS: -> int
 ISSUE_SERVER_COMMAND: command:string -> void

--- a/src/scripting/natives/natives_engine.yaml
+++ b/src/scripting/natives/natives_engine.yaml
@@ -22,6 +22,7 @@ TRACE_FILTER_PROXY_SET_SHOULD_HIT_ENTITY_CALLBACK: trace_filter:pointer, callbac
 NEW_TRACE_RESULT: -> pointer
 GET_TICKED_TIME: -> double
 QUEUE_TASK_FOR_NEXT_FRAME: callback:func -> void
+QUEUE_TASK_FOR_FRAME: tick:int, callback:func -> void
 QUEUE_TASK_FOR_NEXT_WORLD_UPDATE: callback:func -> void
 GET_VALVE_INTERFACE: interfaceType:int, interfaceName:string -> pointer
 GET_COMMAND_PARAM_VALUE: param:string, dataType:DataType_t, defaultValue:any -> any


### PR DESCRIPTION
Adds `RunOnTick` and `RunOnTickAsync` methods which allow you to queue a task for a specific game frame. Closes #367 

Example usage:

```csharp
Server.RunOnTick(Server.TickCount + 64, () => Console.WriteLine("Hello World"));
```

The async overload simply returns a `Task` which can be awaited which resolves once the callback has executed.
