### PR TITLE
Add entities pre and post think

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Listeners.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Listeners.g.cs
@@ -156,12 +156,25 @@ namespace CounterStrikeSharp.API.Core
         [ListenerName("OnServerPreWorldUpdate")]
         public delegate void OnServerPreWorldUpdate(bool simulating);
 
-
         /// <summary>
         /// Called when the server precaching resources (only when initial startup / changing map).
         /// </summary>
         /// <param name="manifest">Resource Manifest</param>
         [ListenerName("OnServerPrecacheResources")]
         public delegate void OnServerPrecacheResources(ResourceManifest manifest);
+
+        /// <summary>
+        /// Called every frame before entities think.
+        /// This handler should avoid containing expensive operations.
+        /// </summary>
+        [ListenerName("OnServerPreEntityThink")]
+        public delegate void OnServerPreEntityThink();
+
+        /// <summary>
+        /// Called every frame after entities think.
+        /// This handler should avoid containing expensive operations.
+        /// </summary>
+        [ListenerName("OnServerPostEntityThink")]
+        public delegate void OnServerPostEntityThink();
     }
 }

--- a/src/core/game_system.cpp
+++ b/src/core/game_system.cpp
@@ -64,3 +64,15 @@ GS_EVENT_MEMBER(CGameSystem, BuildGameSessionManifest)
 
     counterstrikesharp::globals::serverManager.OnPrecacheResources(pResourceManifest);
 }
+
+// Called every frame before entities think
+GS_EVENT_MEMBER(CGameSystem, ServerPreEntityThink)
+{
+    counterstrikesharp::globals::serverManager.OnPreEntityThink();
+}
+
+// Called every frame after entities think
+GS_EVENT_MEMBER(CGameSystem, ServerPostEntityThink)
+{
+    counterstrikesharp::globals::serverManager.OnPostEntityThink();
+}

--- a/src/core/game_system.h
+++ b/src/core/game_system.h
@@ -28,6 +28,8 @@ class CGameSystem : public CBaseGameSystem
 {
   public:
     GS_EVENT(BuildGameSessionManifest);
+    GS_EVENT(ServerPreEntityThink);
+    GS_EVENT(ServerPostEntityThink);
 
     void Shutdown() override
     {

--- a/src/core/managers/server_manager.cpp
+++ b/src/core/managers/server_manager.cpp
@@ -61,6 +61,9 @@ void ServerManager::OnAllInitialized() {
     on_server_pre_world_update = globals::callbackManager.CreateCallback("OnServerPreWorldUpdate");
 
     on_server_precache_resources = globals::callbackManager.CreateCallback("OnServerPrecacheResources");
+
+    on_server_pre_entity_think = globals::callbackManager.CreateCallback("OnServerPreEntityThink");
+    on_server_post_entity_think = globals::callbackManager.CreateCallback("OnServerPostEntityThink");
 }
 
 void ServerManager::OnShutdown() {
@@ -88,6 +91,9 @@ void ServerManager::OnShutdown() {
     globals::callbackManager.ReleaseCallback(on_server_pre_world_update);
     
     globals::callbackManager.ReleaseCallback(on_server_precache_resources);
+
+    globals::callbackManager.ReleaseCallback(on_server_pre_entity_think);
+    globals::callbackManager.ReleaseCallback(on_server_post_entity_think);
 }
 
 void* ServerManager::GetEconItemSystem()
@@ -211,6 +217,24 @@ void ServerManager::OnPrecacheResources(IEntityResourceManifest* pResourceManife
     if (callback && callback->GetFunctionCount()) {
         callback->ScriptContext().Reset();
         callback->ScriptContext().Push(pResourceManifest);
+        callback->Execute();
+    }
+}
+
+void ServerManager::OnPreEntityThink()
+{
+    auto callback = globals::serverManager.on_server_pre_entity_think;
+    if (callback && callback->GetFunctionCount()) {
+        callback->ScriptContext().Reset();
+        callback->Execute();
+    }
+}
+
+void ServerManager::OnPostEntityThink()
+{
+    auto callback = globals::serverManager.on_server_post_entity_think;
+    if (callback && callback->GetFunctionCount()) {
+        callback->ScriptContext().Reset();
         callback->Execute();
     }
 }

--- a/src/core/managers/server_manager.h
+++ b/src/core/managers/server_manager.h
@@ -37,7 +37,10 @@ public:
     void AddTaskForNextWorldUpdate(std::function<void()>&& task);
     void OnPrecacheResources(IEntityResourceManifest* pResourceManifest);
 
-private:
+    void OnPreEntityThink();
+    void OnPostEntityThink();
+
+  private:
     void ServerHibernationUpdate(bool bHibernating);
     void GameServerSteamAPIActivated();
     void GameServerSteamAPIDeactivated();
@@ -56,6 +59,9 @@ private:
     ScriptCallback *on_server_pre_world_update;
 
     ScriptCallback *on_server_precache_resources;
+
+    ScriptCallback *on_server_pre_entity_think;
+    ScriptCallback *on_server_post_entity_think;
 
     moodycamel::ConcurrentQueue<std::function<void()>> m_nextWorldUpdateTasks;
 };

--- a/src/scripting/listeners/server.yaml
+++ b/src/scripting/listeners/server.yaml
@@ -5,3 +5,6 @@ OnHostNameChanged: hostname:string
 PreFatalShutdown:
 UpdateWhenNotInGame: frameTime:float
 PreWorldUpdate: simulating:bool
+OnPrecacheResources: resourceManifest:pointer
+OnPreEntityThink:
+OnPostEntityThink:    


### PR DESCRIPTION
This will called every frame before/after entities think (maybe it will give some benefit to some features?)

Example:
```C#
RegisterListener<Listeners.OnServerPreEntityThink>(() =>
{
    // do something
});

RegisterListener<Listeners.OnServerPostEntityThink>(() =>
{
    // do something
});
```