### PR TITLE
Add `RemoveAll` method to `NetworkedVector` class

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -1096,6 +1096,16 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+        public static void RemoveAllNetworkVectorElements(IntPtr vec){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.Push(vec);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x67206C08);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
         public static short GetSchemaOffset(string classname, string propname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();

--- a/managed/CounterStrikeSharp.API/Core/Model/NetworkedVector.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/NetworkedVector.cs
@@ -33,6 +33,11 @@ public partial class NetworkedVector<T> : NativeObject, IReadOnlyCollection<T>
         }
     }
 
+    public void RemoveAll()
+    {
+        NativeAPI.RemoveAllNetworkVectorElements(Handle);
+    }
+
     public IEnumerator<T> GetEnumerator()
     {
         for (int i = 0; i < Count; i++)

--- a/src/scripting/natives/natives_memory.cpp
+++ b/src/scripting/natives/natives_memory.cpp
@@ -159,6 +159,13 @@ void* GetNetworkVectorElementAt(ScriptContext& script_context)
     return &vec->Element(index);
 }
 
+void RemoveAllNetworkVectorElements(ScriptContext& script_context)
+{
+    auto vec = script_context.GetArgument<CUtlVector<CEntityHandle>*>(0);
+
+    vec->RemoveAll();
+}
+
 REGISTER_NATIVES(memory, {
     ScriptEngine::RegisterNativeHandler("CREATE_VIRTUAL_FUNCTION", CreateVirtualFunction);
     ScriptEngine::RegisterNativeHandler("CREATE_VIRTUAL_FUNCTION_BY_SIGNATURE",
@@ -169,5 +176,6 @@ REGISTER_NATIVES(memory, {
     ScriptEngine::RegisterNativeHandler("FIND_SIGNATURE", FindSignatureNative);
     ScriptEngine::RegisterNativeHandler("GET_NETWORK_VECTOR_SIZE", GetNetworkVectorSize);
     ScriptEngine::RegisterNativeHandler("GET_NETWORK_VECTOR_ELEMENT_AT", GetNetworkVectorElementAt);
+    ScriptEngine::RegisterNativeHandler("REMOVE_ALL_NETWORK_VECTOR_ELEMENTS", RemoveAllNetworkVectorElements);
 })
 } // namespace counterstrikesharp


### PR DESCRIPTION
This PR adds the `RemoveAll` method to `NetworkedVector` class.