### PR TITLE
Fix backwards compatibility in DynamicHook

### DIFF
--- a/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/DynamicHook.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/DynamicHook.cs
@@ -14,6 +14,7 @@ public class DynamicHook : NativeObject
         return NativeAPI.DynamicHookGetParam<T>(Handle, (int)typeof(T).ToValidDataType(), index);
     }
 
+    [Obsolete("Use GetReturn<T>() instead")]
     public T GetReturn<T>(int index)
     {
         return GetReturn<T>();

--- a/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/DynamicHook.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/DynamicHook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using CounterStrikeSharp.API.Core;
 
 namespace CounterStrikeSharp.API.Modules.Memory.DynamicFunctions;
@@ -14,6 +14,11 @@ public class DynamicHook : NativeObject
         return NativeAPI.DynamicHookGetParam<T>(Handle, (int)typeof(T).ToValidDataType(), index);
     }
 
+    public T GetReturn<T>(int index)
+    {
+        return GetReturn<T>();
+    }
+    
     public T GetReturn<T>()
     {
         return NativeAPI.DynamicHookGetReturn<T>(Handle, (int)typeof(T).ToValidDataType());


### PR DESCRIPTION
Re-add the unused parameter with a overload because it breaks plugins not updated to also remove said parameter