### PR TITLE
Update .clang-format & add formatting tool install scripts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,20 +10,63 @@ LineEnding: LF
 InsertNewlineAtEOF: true
 DerivePointerAlignment: false
 
-PointerAlignment: Left
 AlignAfterOpenBracket: Align
 KeepEmptyLinesAtTheStartOfBlocks: false
-SortIncludes: false
 SpaceBeforeParens: ControlStatements
 AllowAllArgumentsOnNextLine: true
-AllowShortIfStatementsOnASingleLine: false
-IndentCaseLabels: false
+IndentCaseLabels: true
+
+# Line Breaks
 BreakBeforeBraces: Custom
 BraceWrapping:
+  AfterCaseLabel: true
   AfterClass: true
-  AfterStruct: true
+  AfterControlStatement: Always
   AfterEnum: true
-  AfterUnion: true
-  AfterNamespace: false
   AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
   IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+PointerAlignment: Left
+SortIncludes: CaseSensitive
+IncludeBlocks: Regroup
+IncludeCategories:
+  # External headers in <> with extension or /
+  - Regex: '<[-\w\/-_]+[\.\/][-\w\/-_]+>'
+    Priority: 2
+  # Standard headers in <>
+  - Regex: '<[-\w\/-_]+>'
+    Priority: 3
+  # Local headers in ""
+  - Regex: '"[-\w\/-_]*"'
+    Priority: 4
+
+ReflowComments: true
+CompactNamespaces: false
+Cpp11BracedListStyle: false
+
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+
+AlignEscapedNewlines: Left
+AlignTrailingComments: Never
+
+AllowShortBlocksOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: OnlyFirstIf
+AllowShortLambdasOnASingleLine: Empty
+BinPackArguments: true
+BinPackParameters: false
+
+LambdaBodyIndentation: OuterScope

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,15 @@
 BasedOnStyle: LLVM
+
+# Spacing
 IndentWidth: 4
-ColumnLimit: 100
+UseTab: Never
+ColumnLimit: 140
+
+# Line Endings
+LineEnding: LF
+InsertNewlineAtEOF: true
 DerivePointerAlignment: false
+
 PointerAlignment: Left
 AlignAfterOpenBracket: Align
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+max_line_length = 140
+trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .cmake/
 cmake-build-*/
 .kdev4/
-.vscode/
 generated/
 
 # configure_file auto generated.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": null,
+  "editor.formatOnSave": true
+}

--- a/eng/formatting/download-tools.ps1
+++ b/eng/formatting/download-tools.ps1
@@ -1,0 +1,37 @@
+# Tool taken from dotnet/runtime
+# https://github.com/dotnet/runtime/blob/a8158c170b694f8c1dbae114c63c346b38244901/eng/formatting/download-tools.ps1
+
+function DownloadClangTool {
+    param (
+        [string]
+        $toolName,
+        [string]
+        $downloadOutputPath
+    )
+
+    $clangVersion = "17.0.6"
+    $clangToolsRootUrl = "https://clrjit2.blob.core.windows.net/clang-tools"
+    $clangPlatform = "windows-x64"
+
+    $toolUrl = "$clangToolsRootUrl/$clangVersion/$clangPlatform/$toolName.exe"
+    $targetPath = "$downloadOutputPath\$toolName.exe" 
+
+    if (-not $(ls $downloadOutputPath | Where-Object { $_.Name -eq "$toolName.exe" })) {
+        Write-Output "Downloading '$toolUrl' to '$targetPath'"
+        # Pass -PassThru as otherwise Invoke-WebRequest leaves a corrupted file if the download fails. With -PassThru the download is buffered first.
+        # -UseBasicParsing is necessary for older PowerShells when Internet Explorer might not be installed/configured
+        $null = Invoke-WebRequest -Uri "$toolUrl" -OutFile $(Join-Path $downloadOutputPath -ChildPath "$toolName.exe") -PassThru -UseBasicParsing
+    }
+    else {
+        Write-Output "Found '$targetPath'"
+    }
+}
+
+$downloadPathFolder = Split-Path $PSScriptRoot -Parent | Split-Path -Parent | Join-Path -ChildPath "artifacts" | Join-Path -ChildPath "tools"
+
+mkdir $downloadPathFolder -ErrorAction SilentlyContinue
+
+DownloadClangTool "clang-format" "$downloadPathFolder"
+
+# Add to path to enable scripts to skip additional downloading steps since the tools will already be on the path.
+$env:PATH = "$downloadPathFolder;$env:PATH"

--- a/eng/formatting/download-tools.sh
+++ b/eng/formatting/download-tools.sh
@@ -1,0 +1,60 @@
+# Tool taken from dotnet/runtime
+# https://github.com/dotnet/runtime/blob/a8158c170b694f8c1dbae114c63c346b38244901/eng/formatting/download-tools.sh
+
+#!/usr/bin/env bash
+
+set -ue
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $source until the file is no longer a symlink
+while [[ -h "$source" ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+function DownloadClangTool {
+
+    clangVersion="17.0.6"
+    clangToolsRootUrl="https://clrjit2.blob.core.windows.net/clang-tools"
+
+    clangPlatform="$(dotnet --info | grep 'RID:')"
+    clangPlatform="${clangPlatform##*RID:* }"
+    echo "dotnet RID: ${clangPlatform}"
+
+    # override common RIDs with compatible version so we don't need to upload binaries for each RID
+    case $clangPlatform in
+        ubuntu.*-x64)
+        clangPlatform=linux-x64
+        ;;
+    esac
+
+    toolUrl="${clangToolsRootUrl}/${clangVersion}/${clangPlatform}/$1"
+    toolOutput=$2/$1
+
+    echo "Downloading $1 from ${toolUrl} to ${toolOutput}"
+
+    if [[ ! -x "$toolOutput" ]]; then
+        curl --silent --retry 5 --fail -o "${toolOutput}" "$toolUrl"
+        chmod 751 $toolOutput
+    fi
+
+    if [[ ! -x "$toolOutput" ]]; then
+        echo "Failed to download $1"
+        exit 1
+    fi
+}
+
+
+engFolder="$(cd -P "$( dirname "$scriptroot" )" && pwd )"
+downloadPathFolder="$(cd -P "$( dirname "$engFolder" )" && pwd )/artifacts/tools"
+
+mkdir -p "$downloadPathFolder"
+
+DownloadClangTool "clang-format" "$downloadPathFolder"
+
+export PATH=$downloadPathFolder:$PATH

--- a/eng/formatting/format.sh
+++ b/eng/formatting/format.sh
@@ -1,0 +1,29 @@
+# Tool taken from dotnet/runtime
+# https://github.com/dotnet/runtime/blob/a8158c170b694f8c1dbae114c63c346b38244901/eng/formatting/format.sh
+
+#!/bin/sh
+
+LC_ALL=C
+# Select files to format
+NATIVE_FILES=$(git diff --cached --name-only --diff-filter=ACM "*.h" "*.hpp" "*.c" "*.cpp" "*.inl" | sed 's| |\\ |g')
+MANAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM "*.cs" "*.vb" | sed 's| |\\ |g')
+
+exec 1>&2
+
+if [ -n "$NATIVE_FILES" ]; then
+    # Format all selected files
+    echo "$NATIVE_FILES" | cat | xargs | sed -e 's/ /,/g' | xargs "./artifacts/tools/clang-format" -style=file -i
+
+    # Add back the modified files to staging
+    echo "$NATIVE_FILES" | xargs git add
+fi
+
+if [ -n "$MANAGED_FILES" ]; then
+    # Format all selected files
+    echo "$MANAGED_FILES" | cat | xargs | sed -e 's/ /,/g' | dotnet format whitespace --include - --folder
+
+    # Add back the modified files to staging
+    echo "$MANAGED_FILES" | xargs git add
+fi
+
+exit 0


### PR DESCRIPTION
- Update .clang-format with more prescriptive rules
- Add scripts to download a local copy of clang-format
- Add basic .editorconfig with line ending and spacing configuration
- Add format on save vscode workspace settings 