### PR TITLE
The fix of getplayers

### DIFF
--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -144,6 +144,9 @@ namespace CounterStrikeSharp.API
 
                 if (!controller.IsValid || controller.UserId == -1)
                     continue;
+                
+                if (!controller.SteamID.ToString().Length != 17)
+                    continue;
 
                 players.Add(controller);
             }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -145,7 +145,7 @@ namespace CounterStrikeSharp.API
                 if (!controller.IsValid || controller.UserId == -1)
                     continue;
                 
-                if (!controller.SteamID.ToString().Length != 17)
+                if (controller.SteamID.ToString().Length != 17 || string.IsNullOrEmpty(controller.IpAddress) || controller.Connected != PlayerConnectedState.PlayerConnected)
                     continue;
 
                 players.Add(controller);


### PR DESCRIPTION
Ignoring ghost players who are not in the game, based on their SteamID, IP address, and connection status.