### PR TITLE
Make shared type loader less strict

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs
@@ -36,7 +36,7 @@ public class PluginManager : IPluginManager
             config => { config.PreferSharedTypes = true; });
         var assembly = loader.LoadDefaultAssembly();
 
-        _sharedAssemblies[assembly.GetName().FullName] = assembly;
+        _sharedAssemblies[assembly.GetName().Name] = assembly;
     }
 
     private void LoadSharedLibraries()
@@ -76,7 +76,7 @@ public class PluginManager : IPluginManager
                 _loadedSharedLibs = true;
             }
 
-            if (!_sharedAssemblies.TryGetValue(name.FullName, out var assembly))
+            if (!_sharedAssemblies.TryGetValue(name.Name, out var assembly))
             {
                 return null;
             }


### PR DESCRIPTION
I propose this change as I don't think we should be this strict when we are loading shared types.
Currently when a shared type is loaded it is saved with assembly build version and plugins that depends on other shared type(s) cannot be loaded if the shared type version has changed, even if there are no breaking changes as the shared type just cannot be found at all (or version mismatch)

this pr changes this behaviour and it only looks for the shared type name and loads it, I believe developers should be aware of the changes of the shared type they depend on, just like how it works with the core api.