### PR TITLE
chore: use offsets for give named item

### DIFF
--- a/configs/addons/counterstrikesharp/gamedata/gamedata.json
+++ b/configs/addons/counterstrikesharp/gamedata/gamedata.json
@@ -81,6 +81,12 @@
       "linux": "\\x48\\x85\\xF6\\x0F\\x84\\x2A\\x2A\\x2A\\x2A\\x55\\x31\\xC9\\x48\\x89\\xE5\\x41\\x55\\x49\\x89\\xFD"
     }
   },
+  "CCSPlayer_ItemServices_GiveNamedItem": {
+    "offsets": {
+      "windows": 17,
+      "linux": 18
+    }
+  },
   "CCSPlayer_ItemServices_DropActivePlayerWeapon": {
     "offsets": {
       "windows": 18,

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
@@ -16,17 +16,22 @@ public partial class CCSPlayerController
     /// <exception cref="InvalidOperationException">Entity is not valid</exception>
     public IntPtr GiveNamedItem(string item)
     {
-        Guard.IsValidEntity(this);
-
-        if (!PlayerPawn.IsValid) return 0;
-        if (PlayerPawn.Value == null) return 0;
-        if (!PlayerPawn.Value.IsValid) return 0;
-        if (PlayerPawn.Value.ItemServices == null) return 0;
-
-        return VirtualFunctions.GiveNamedItem(PlayerPawn.Value.ItemServices.Handle, item, 0, 0, 0, 0);
+        return GiveNamedItem<CEntityInstance>(item)?.Handle ?? IntPtr.Zero;
     }
 
-    public IntPtr GiveNamedItem(CsItem item) 
+    public T? GiveNamedItem<T>(string item) where T : CEntityInstance
+    {
+        Guard.IsValidEntity(this);
+
+        if (!PlayerPawn.IsValid) return null;
+        if (PlayerPawn.Value == null) return null;;
+        if (!PlayerPawn.Value.IsValid) return null;
+        if (PlayerPawn.Value.ItemServices == null) return null;
+
+        return PlayerPawn.Value.ItemServices.As<CCSPlayer_ItemServices>().GiveNamedItem<T>(item);
+    }
+
+    public IntPtr GiveNamedItem(CsItem item)
     {
         string? itemString = EnumUtils.GetEnumMemberAttributeValue(item);
         if (string.IsNullOrWhiteSpace(itemString))
@@ -94,7 +99,7 @@ public partial class CCSPlayerController
 
         CCSPlayer_ItemServices itemServices = new CCSPlayer_ItemServices(PlayerPawn.Value.ItemServices.Handle);
         CCSPlayer_WeaponServices weaponServices = new CCSPlayer_WeaponServices(PlayerPawn.Value.WeaponServices.Handle);
-        
+
         itemServices.DropActivePlayerWeapon(weaponServices.ActiveWeapon.Value);
     }
 

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
@@ -45,4 +45,13 @@ public partial class CCSPlayer_ItemServices
 
         VirtualFunction.CreateVoid<nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_RemoveWeapons"))(Handle);
     }
+
+    public T? GiveNamedItem<T>(string item) where T : CEntityInstance
+    {
+        var pointer = VirtualFunction.Create<nint, string, nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_GiveNamedItem"))(Handle, item);
+        if (pointer == IntPtr.Zero)
+            return null;
+
+        return (T)Activator.CreateInstance(typeof(T), pointer)!;
+    }
 }


### PR DESCRIPTION
- Adds offsets for GiveNamedItem
- Adds method to `CCSPlayer_ItemServices`
- Updates method in `CCSPlayerController` to use this new method
- Adds generic overload for GiveNamedItem which accepts `T : CEntityInstance`, so you can do `player.GiveNamedItem<CCSWeaponBaseGun>("weapon_ak47");` and get the proper type back.