### PR TITLE
Change example command prefix to follow "best practice"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ public class HelloWorldPlugin : BasePlugin
         return HookResult.Continue;
     }
 
-    [ConsoleCommand("issue_warning", "Issue warning to player")]
+    [ConsoleCommand("css_issue_warning", "Issue warning to player")]
     public void OnCommand(CCSPlayerController? player, CommandInfo command)
     {
         Logger.LogWarning("Player shouldn't be doing that");


### PR DESCRIPTION
Every other example as far as i've seen uses "css_" as prefix except from this one