### PR TITLE
CoreConfig: Prevent "Error invoking callback" if core.json not found

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
+++ b/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
@@ -151,27 +151,28 @@ namespace CounterStrikeSharp.API.Core
                 _commandsRegistered = true;
             }
 
-            if (!File.Exists(_coreConfigPath))
+            if (File.Exists(_coreConfigPath))
+            {
+                try
+                {
+                    var data = JsonSerializer.Deserialize<CoreConfigData>(File.ReadAllText(_coreConfigPath),
+                        new JsonSerializerOptions() { ReadCommentHandling = JsonCommentHandling.Skip });
+    
+                    if (data != null)
+                    {
+                        _coreConfig = data;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to load core configuration, fallback values will be used");
+                }
+            }
+            else
             {
                 _logger.LogWarning(
                     "Core configuration could not be found at path \"{CoreConfigPath}\", fallback values will be used.",
                     _coreConfigPath);
-                return;
-            }
-
-            try
-            {
-                var data = JsonSerializer.Deserialize<CoreConfigData>(File.ReadAllText(_coreConfigPath),
-                    new JsonSerializerOptions() { ReadCommentHandling = JsonCommentHandling.Skip });
-
-                if (data != null)
-                {
-                    _coreConfig = data;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to load core configuration, fallback values will be used");
             }
 
             var serverCulture = CultureInfo.GetCultures(CultureTypes.AllCultures)


### PR DESCRIPTION
Fixes the following exception if `core.json` is not found

```
15:35:23 [EROR] (cssharp:Core) Error invoking callback
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
---> System.ArgumentNullException: Value cannot be null. (Parameter 'value')
at System.ArgumentNullException.Throw(String paramName)
at System.Globalization.CultureInfo.set_CurrentCulture(CultureInfo value)
at CounterStrikeSharp.API.Core.Translations.WithTemporaryCulture.SetCulture(CultureInfo cultureInfo) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Translations/WithTemporaryCulture.cs:line 17
at CounterStrikeSharp.API.Core.Translations.WithTemporaryCulture..ctor(CultureInfo culture) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Translations/WithTemporaryCulture.cs:line 12
at CounterStrikeSharp.API.Core.Commands.CommandManager.HandleCommandInternal(Int32 playerSlot, IntPtr commandInfo) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Commands/CommandManager.cs:line 69
at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
--- End of inner exception stack trace ---
at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
at System.Delegate.DynamicInvokeImpl(Object[] args)
at CounterStrikeSharp.API.Core.FunctionReference.<CreateWrappedCallback>b__18_0(fxScriptContext* context) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/FunctionReference.cs:line 100
```

PS: I think we used to write `core.json` from `core.example.json` before, but seems like that's not happening anymore?