### PR TITLE
Fix calling Send using UM instance from UM hook

### DIFF
--- a/src/core/UserMessage.h
+++ b/src/core/UserMessage.h
@@ -132,6 +132,7 @@ class UserMessage
     const CNetMessagePB<google::protobuf::Message>* GetProtobufMessage();
     INetworkMessageInternal* GetSerializableMessage() { return msgSerializable; }
     uint64* GetRecipientMask() { return recipientMask; }
+    bool IsManuallyAllocated() { return manuallyAllocated; }
 
   private:
     CNetMessagePB<google::protobuf::Message>* msg = nullptr;

--- a/src/scripting/natives/natives_usermessages.cpp
+++ b/src/scripting/natives/natives_usermessages.cpp
@@ -620,7 +620,13 @@ static void UserMessageSend(ScriptContext& scriptContext)
     CRecipientFilter filter{};
     filter.AddRecipientsFromMask(message->GetRecipientMask() ? *message->GetRecipientMask() : 0);
 
-    globals::gameEventSystem->PostEventAbstract(0, false, &filter, message->GetSerializableMessage(), message->GetProtobufMessage(), 0);
+    // This is for calling send in a UM hook, if calling normal send using the UM instance from the UM hook, it will cause an inifinite loop, then crashing the server
+    static void (IGameEventSystem::*PostEventAbstract)(CSplitScreenSlot, bool, IRecipientFilter*, INetworkMessageInternal*, const CNetMessage*, unsigned long) = &IGameEventSystem::PostEventAbstract;
+
+    if (message->IsManuallyAllocated())
+        globals::gameEventSystem->PostEventAbstract(0, false, &filter, message->GetSerializableMessage(), message->GetProtobufMessage(), 0);
+    else
+        SH_CALL(globals::gameEventSystem, PostEventAbstract)(0, false, &filter, message->GetSerializableMessage(), message->GetProtobufMessage(), 0);
 }
 
 static void UserMessageDelete(ScriptContext& scriptContext)


### PR DESCRIPTION
This should fix the use case below
```C#
public HookResult Hook_WeaponFiring(UserMessage userMessage)
{
    var weaponid = userMessage.ReadUInt("weapon_id");
    var soundType = userMessage.ReadInt("sound_type");
    var itemdefindex = userMessage.ReadUInt("item_def_index");

    userMessage.SetUInt("weapon_id", 0);
    userMessage.SetInt("sound_type", 9);
    userMessage.SetUInt("item_def_index", 61);

    // send for people who use silencer.
    userMessage.Recipients = new(silencer);
    userMessage.Send();

    userMessage.SetUInt("weapon_id", weaponid);
    userMessage.SetInt("sound_type", soundType);
    userMessage.SetUInt("item_def_index", itemdefindex);

    userMessage.Recipients = new(normal);

    return HookResult.Continue;
}
```
Code is from [https://github.com/oylsister/StopSound/commit/95998e32d630a0f016c5b2f60d6d166e224c2a30](https://github.com/oylsister/StopSound/commit/95998e32d630a0f016c5b2f60d6d166e224c2a30)