### PR TITLE
fix: `InvalidOperationException` when removing command in its callback

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Commands/CommandManager.cs
+++ b/managed/CounterStrikeSharp.API/Core/Commands/CommandManager.cs
@@ -70,8 +70,13 @@ public class CommandManager : ICommandManager
 
         if (_commandDefinitions.TryGetValue(name, out var handler))
         {
-            foreach (var command in handler)
+            foreach (var command in handler.ToList())
             {
+                if (!handler.Contains(command))
+                {
+                    continue;
+                }
+
                 var methodInfo = command.Callback?.GetMethodInfo();
 
                 // We do not need to do permission checks on commands executed from the server console.


### PR DESCRIPTION
This PR fixes a scenario where a command calls BasePlugin::RemoveCommand for its own callback; currently, an InvalidOperationException is thrown. See the sample plugin below.

```c#
using CounterStrikeSharp.API.Core;
using CounterStrikeSharp.API.Modules.Commands;

namespace SamplePlugin;

public class SamplePlugin : BasePlugin
{
    public override string ModuleName => "SamplePlugin";
    public override string ModuleVersion => "0.0.1";

    public override void Load(bool hotReload)
    {
        AddCommand("css_print_once", "Prints message once.", OnPrintOnceCommand);
    }

    public void OnPrintOnceCommand(CCSPlayerController? controller, CommandInfo _)
    {
        controller?.PrintToChat($"Hello, World!");
        RemoveCommand("css_print_once", OnPrintOnceCommand);
    }
}

```