### PR TITLE
feat: handle quotes for `FakeConVar<string>`

### DIFF
--- a/managed/CounterStrikeSharp.API/Modules/Cvars/FakeConVar.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Cvars/FakeConVar.cs
@@ -76,9 +76,7 @@ public class FakeConVar<T> where T : IComparable<T>
             
             if (typeof(T) == typeof(string))
             {
-                if (argString.Length >= 2
-                    && argString.StartsWith('"')
-                    && argString.EndsWith('"'))
+                if (argString.Length >= 2 && argString.StartsWith('"') && argString.EndsWith('"'))
                 {
                     argString = argString.Substring(1, argString.Length - 2);
                 }

--- a/managed/CounterStrikeSharp.API/Modules/Cvars/FakeConVar.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Cvars/FakeConVar.cs
@@ -72,6 +72,18 @@ public class FakeConVar<T> where T : IComparable<T>
 
         try
         {
+            var argString = args.ArgString;
+            
+            if (typeof(T) == typeof(string))
+            {
+                if (argString.Length >= 2 &&
+                    argString.StartsWith("\"") &&
+                    argString.EndsWith("\""))
+                {
+                    argString = argString.Substring(1, argString.Length - 2);
+                }
+            }
+            
             // TODO(dotnet8): Replace with IParsable<T>
             bool success = true;
             T parsedValue = default(T);
@@ -80,11 +92,11 @@ public class FakeConVar<T> where T : IComparable<T>
             {
                 try
                 {
-                    parsedValue = (T)converter.ConvertFromString(args.ArgString);
+                    parsedValue = (T)converter.ConvertFromString(argString);
                 }
                 catch
                 {
-                    success = typeof(T) == typeof(bool) && TryConvertCustomBoolean(args.ArgString, out parsedValue);
+                    success = typeof(T) == typeof(bool) && TryConvertCustomBoolean(argString, out parsedValue);
                 }
             }
 

--- a/managed/CounterStrikeSharp.API/Modules/Cvars/FakeConVar.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Cvars/FakeConVar.cs
@@ -76,9 +76,9 @@ public class FakeConVar<T> where T : IComparable<T>
             
             if (typeof(T) == typeof(string))
             {
-                if (argString.Length >= 2 &&
-                    argString.StartsWith("\"") &&
-                    argString.EndsWith("\""))
+                if (argString.Length >= 2
+                    && argString.StartsWith('"')
+                    && argString.EndsWith('"'))
                 {
                     argString = argString.Substring(1, argString.Length - 2);
                 }


### PR DESCRIPTION
When trying to set URLs into `FakeConVar`s, the server doesn't parse it properly.

```sh
my_string_convar https://example.com
# my_string_convar.Value = "https:"

my_string_convar "https://example.com"
# my_string_convar.Value = "\"https://example.com\""
```

After this PR, the second case should work as expected. The first case seems to be the way the server parses the argument once we send the command, so nothing much we can do about it. The value needs to be wrapped into quotes to be extracted from them.

```sh
my_string_convar https://example.com
# my_string_convar.Value = "https:"

my_string_convar "https://example.com"
# my_string_convar.Value = "https://example.com"
```