### PR TITLE
feat: add `ListenerHandlerAttribute<T>`

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Attributes/Registration/ListenerHandlerAttribute.cs
+++ b/managed/CounterStrikeSharp.API/Core/Attributes/Registration/ListenerHandlerAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CounterStrikeSharp.API.Core.Attributes.Registration;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class ListenerHandlerAttribute<T> : Attribute
+    where T: Delegate
+{
+}

--- a/managed/TestPlugin/TestPlugin.cs
+++ b/managed/TestPlugin/TestPlugin.cs
@@ -392,6 +392,16 @@ namespace TestPlugin
             return HookResult.Continue;
         }
 
+        [ListenerHandler<Listeners.OnClientPutInServer>]
+        public void OnClientPutInServer(int playerSlot)
+        {
+            var player = Utilities.GetPlayerFromSlot(playerSlot);
+
+            if (player == null || player.IsBot) return;
+
+            player.PrintToChat("Welcome to the server!");
+        }
+
         [ConsoleCommand("css_testinput", "Test AcceptInput and AddEntityIOEvent")]
         public void OnTestInput(CCSPlayerController? player, CommandInfo command)
         {


### PR DESCRIPTION
Adds a feature listener registration via attributes. Loading & unloading of the plugin has been verified. If `T` represents a delegate that does not have a `ListenerName` attribute, will be thrown `ArgumentException`, similar to how `RegisterListener` works.

```c#
public class Plugin : BasePlugin
{
    public override string ModuleName => "TestPlugin";
    public override string ModuleVersion => "1.0.0";

    [ListenerHandler<Listeners.OnServerPreWorldUpdate>]
    public void OnServerPreWorldUpdate(bool simulating)
    {
        if (Server.TickCount % 128 == 0)
        {
            Logger.LogInformation("Tick: {count}", Server.TickCount);
        }
    }

    [ListenerHandler<Listeners.OnClientPutInServer>]
    public void OnClientPutInServer(int playerSlot)
    {
        var player = Utilities.GetPlayerFromSlot(playerSlot);

        if (player == null || player.IsBot) return;
        
        player.PrintToChat("Welcome to the server!");
    }
}
```