### PR TITLE
Restore HTML menu max length, but as an optional feature and improved the trimming with HTML banners

### DIFF
--- a/configs/addons/counterstrikesharp/configs/core.example.json
+++ b/configs/addons/counterstrikesharp/configs/core.example.json
@@ -7,6 +7,6 @@
     "ServerLanguage": "en",
     "UnlockConCommands": true,
     "UnlockConVars": true,
-    "MaxHtmlMenuTitleLength": 0, // 0 = unlimited, previous value = 32
-    "MaxHtmlMenuOptionLength": 0, // 0 = unlimited, previous value = 26
+    "MaxHtmlMenuTitleLength": 0,
+    "MaxHtmlMenuOptionLength": 0
 }

--- a/configs/addons/counterstrikesharp/configs/core.example.json
+++ b/configs/addons/counterstrikesharp/configs/core.example.json
@@ -6,5 +6,7 @@
     "PluginAutoLoadEnabled": true,
     "ServerLanguage": "en",
     "UnlockConCommands": true,
-    "UnlockConVars": true
+    "UnlockConVars": true,
+    "MaxHtmlMenuTitleLength": 0, // 0 = unlimited, previous value = 32
+    "MaxHtmlMenuOptionLength": 0, // 0 = unlimited, previous value = 26
 }

--- a/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
+++ b/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
@@ -61,6 +61,12 @@ namespace CounterStrikeSharp.API.Core
 
         [JsonPropertyName("UnlockConVars")]
         public bool UnlockConVars { get; set; } = true;
+        
+        [JsonPropertyName("MaxHtmlMenuTitleLength")]
+        public int MaxHtmlMenuTitleLength { get; set; } = 0;
+        
+        [JsonPropertyName("MaxHtmlMenuOptionLength")]
+        public int MaxHtmlMenuOptionLength { get; set; } = 0;
     }
 
     /// <summary>
@@ -114,7 +120,10 @@ namespace CounterStrikeSharp.API.Core
         public static bool UnlockConCommands => _coreConfig.UnlockConCommands;
 
         public static bool UnlockConVars => _coreConfig.UnlockConVars;
-
+        
+        public static int MaxHtmlMenuTitleLength => _coreConfig.MaxHtmlMenuTitleLength;
+        
+        public static int MaxHtmlMenuOptionLength => _coreConfig.MaxHtmlMenuOptionLength;
     }
 
     public partial class CoreConfig : IStartupService

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -29,13 +29,13 @@ public class CenterHtmlMenu : BaseMenu
     public string NextPageColor { get; set; } = "yellow";
     public string CloseColor { get; set; } = "red";
 
-    public CenterHtmlMenu(string title, BasePlugin plugin) : base(title)
+    public CenterHtmlMenu(string title, BasePlugin plugin) : base(title.TruncateHtmlTitle())
     {
         _plugin = plugin;
     }
 
     [Obsolete("Use the constructor that takes a BasePlugin")]
-    public CenterHtmlMenu(string title) : base(title)
+    public CenterHtmlMenu(string title) : base(title.TruncateHtmlTitle())
     {
     }
 
@@ -53,7 +53,7 @@ public class CenterHtmlMenu : BaseMenu
     public override ChatMenuOption AddMenuOption(string display, Action<CCSPlayerController, ChatMenuOption> onSelect,
         bool disabled = false)
     {
-        var option = new ChatMenuOption(display, disabled, onSelect);
+        var option = new ChatMenuOption(display.TruncateHtmlOption(), disabled, onSelect);
         MenuOptions.Add(option);
         return option;
     }

--- a/managed/CounterStrikeSharp.API/StringExtensions.cs
+++ b/managed/CounterStrikeSharp.API/StringExtensions.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CounterStrikeSharp.API
+{
+	public static class StringExtensions
+	{
+		private const string HTML_TAG_REGEX_PATTERN = "<[^>]+>";
+		private static readonly Regex TagRegex = new(HTML_TAG_REGEX_PATTERN, RegexOptions.Compiled);
+
+		public static string TruncateHtmlTitle(this string msg)
+		{
+			int titleMaxLength = CoreConfig.MaxHtmlMenuTitleLength;
+			return TruncateHtml(msg, titleMaxLength);
+		}
+
+		public static string TruncateHtmlOption(this string msg)
+		{
+			int titleMaxLength = CoreConfig.MaxHtmlMenuOptionLength;
+			return TruncateHtml(msg, titleMaxLength);
+		}
+
+		public static string TruncateHtml(this string msg, int maxLength)
+		{
+			if (maxLength <= 0)
+				return msg;
+
+			if (string.IsNullOrEmpty(msg))
+				return string.Empty;
+
+			string textOnly = Regex.Replace(msg, HTML_TAG_REGEX_PATTERN, "");
+			if (textOnly.Length <= maxLength)
+				return msg;
+
+			Stack<string> tagStack = new Stack<string>();
+			StringBuilder result = new System.Text.StringBuilder();
+			int visibleLength = 0,
+				i = 0;
+
+			while (i < msg.Length && visibleLength < maxLength)
+			{
+				if (msg[i] == '<')
+				{
+					Match match = TagRegex.Match(msg, i);
+					if (match.Success && match.Index == i)
+					{
+						string tag = match.Value;
+						result.Append(tag);
+						i += tag.Length;
+
+						if (!tag.StartsWith("</")) // Opening tag
+						{
+							string tagName = tag.Split(new[] { ' ', '>' }, StringSplitOptions.RemoveEmptyEntries)[0].Trim('<');
+							if (!tag.EndsWith("/>") && !tagName.StartsWith("!"))
+								tagStack.Push(tagName);
+						}
+						else if (tagStack.Count > 0)
+						{
+							tagStack.Pop();
+						}
+
+						continue;
+					}
+				}
+				else
+				{
+					result.Append(msg[i]);
+					visibleLength++;
+				}
+
+				i++;
+			}
+
+			while (tagStack.Count > 0)
+				result.Append($"</{tagStack.Pop()}>");
+
+			return result.ToString();
+		}
+	}
+}


### PR DESCRIPTION
This PR is following #747

It adds the ability to enable or disable the limit. But it also improves the trimming by not taking HTML banners into account, but it also closes the open banners after trimming to avoid any visual issues.

Example: 
 "<b>Hello</b> <font color='green'>World</font>! This is a test." trimmed to 8 characters will be "<b>Hello</b> <font color='green'>Wo</font>"

To do this, add this in your config:
"MaxHtmlMenuTitleLength": 0, // 0 = unlimited, previous value = 32
"MaxHtmlMenuOptionLength": 0, // 0 = unlimited, previous value = 26`