### PR TITLE
Improve HTML Menu

### DIFF
--- a/configs/addons/counterstrikesharp/configs/core.example.json
+++ b/configs/addons/counterstrikesharp/configs/core.example.json
@@ -5,6 +5,7 @@
     "PluginHotReloadEnabled": true,
     "PluginAutoLoadEnabled": true,
     "ServerLanguage": "en",
+    "InlinePageOptions": true,
     "UnlockConCommands": true,
     "UnlockConVars": true
 }

--- a/configs/addons/counterstrikesharp/configs/core.example.json
+++ b/configs/addons/counterstrikesharp/configs/core.example.json
@@ -8,6 +8,6 @@
     "InlinePageOptions": true,
     "UnlockConCommands": true,
     "UnlockConVars": true,
-    "MaxHtmlMenuTitleLength": 0, // 0 = unlimited, previous value = 32
-    "MaxHtmlMenuOptionLength": 0, // 0 = unlimited, previous value = 26
+    "MaxHtmlMenuTitleLength": 0,
+    "MaxHtmlMenuOptionLength": 0
 }

--- a/configs/addons/counterstrikesharp/configs/core.example.json
+++ b/configs/addons/counterstrikesharp/configs/core.example.json
@@ -7,5 +7,7 @@
     "ServerLanguage": "en",
     "InlinePageOptions": true,
     "UnlockConCommands": true,
-    "UnlockConVars": true
+    "UnlockConVars": true,
+    "MaxHtmlMenuTitleLength": 0, // 0 = unlimited, previous value = 32
+    "MaxHtmlMenuOptionLength": 0, // 0 = unlimited, previous value = 26
 }

--- a/configs/addons/counterstrikesharp/configs/core.example.json
+++ b/configs/addons/counterstrikesharp/configs/core.example.json
@@ -5,9 +5,6 @@
     "PluginHotReloadEnabled": true,
     "PluginAutoLoadEnabled": true,
     "ServerLanguage": "en",
-    "InlinePageOptions": true,
     "UnlockConCommands": true,
-    "UnlockConVars": true,
-    "MaxHtmlMenuTitleLength": 0,
-    "MaxHtmlMenuOptionLength": 0
+    "UnlockConVars": true
 }

--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -206,6 +206,18 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+        public static void ReplicateConvar(int clientslot, string convarname, string convarvalue){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.Push(clientslot);
+			ScriptContext.GlobalScriptContext.Push(convarname);
+			ScriptContext.GlobalScriptContext.Push(convarvalue);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0xC8728BEC);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
         public static T DynamicHookGetReturn<T>(IntPtr hook, int datatype){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();

--- a/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
+++ b/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
@@ -55,21 +55,12 @@ namespace CounterStrikeSharp.API.Core
 
         [JsonPropertyName("ServerLanguage")]
         public string ServerLanguage { get; set; } = "en";
-        
-        [JsonPropertyName("InlinePageOptions")]
-        public bool InlinePageOptions { get; set; } = true;
 
         [JsonPropertyName("UnlockConCommands")]
         public bool UnlockConCommands { get; set; } = true;
 
         [JsonPropertyName("UnlockConVars")]
         public bool UnlockConVars { get; set; } = true;
-        
-        [JsonPropertyName("MaxHtmlMenuTitleLength")]
-        public int MaxHtmlMenuTitleLength { get; set; } = 0;
-        
-        [JsonPropertyName("MaxHtmlMenuOptionLength")]
-        public int MaxHtmlMenuOptionLength { get; set; } = 0;
     }
 
     /// <summary>
@@ -119,15 +110,10 @@ namespace CounterStrikeSharp.API.Core
         public static bool PluginAutoLoadEnabled => _coreConfig.PluginAutoLoadEnabled;
 
         public static string ServerLanguage => _coreConfig.ServerLanguage;
-        public static bool InlinePageOptions => _coreConfig.InlinePageOptions;
 
         public static bool UnlockConCommands => _coreConfig.UnlockConCommands;
 
         public static bool UnlockConVars => _coreConfig.UnlockConVars;
-        
-        public static int MaxHtmlMenuTitleLength => _coreConfig.MaxHtmlMenuTitleLength;
-        
-        public static int MaxHtmlMenuOptionLength => _coreConfig.MaxHtmlMenuOptionLength;
     }
 
     public partial class CoreConfig : IStartupService

--- a/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
+++ b/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
@@ -55,6 +55,9 @@ namespace CounterStrikeSharp.API.Core
 
         [JsonPropertyName("ServerLanguage")]
         public string ServerLanguage { get; set; } = "en";
+        
+        [JsonPropertyName("InlinePageOptions")]
+        public bool InlinePageOptions { get; set; } = true;
 
         [JsonPropertyName("UnlockConCommands")]
         public bool UnlockConCommands { get; set; } = true;
@@ -110,6 +113,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool PluginAutoLoadEnabled => _coreConfig.PluginAutoLoadEnabled;
 
         public static string ServerLanguage => _coreConfig.ServerLanguage;
+        public static bool InlinePageOptions => _coreConfig.InlinePageOptions;
 
         public static bool UnlockConCommands => _coreConfig.UnlockConCommands;
 

--- a/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
+++ b/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
@@ -64,6 +64,12 @@ namespace CounterStrikeSharp.API.Core
 
         [JsonPropertyName("UnlockConVars")]
         public bool UnlockConVars { get; set; } = true;
+        
+        [JsonPropertyName("MaxHtmlMenuTitleLength")]
+        public int MaxHtmlMenuTitleLength { get; set; } = 0;
+        
+        [JsonPropertyName("MaxHtmlMenuOptionLength")]
+        public int MaxHtmlMenuOptionLength { get; set; } = 0;
     }
 
     /// <summary>
@@ -118,7 +124,10 @@ namespace CounterStrikeSharp.API.Core
         public static bool UnlockConCommands => _coreConfig.UnlockConCommands;
 
         public static bool UnlockConVars => _coreConfig.UnlockConVars;
-
+        
+        public static int MaxHtmlMenuTitleLength => _coreConfig.MaxHtmlMenuTitleLength;
+        
+        public static int MaxHtmlMenuOptionLength => _coreConfig.MaxHtmlMenuOptionLength;
     }
 
     public partial class CoreConfig : IStartupService

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayerController.cs
@@ -347,4 +347,9 @@ public partial class CCSPlayerController
     {
         base.Teleport(position, angles, velocity);
     }
+
+    public void ReplicateConVar(string conVar, string value)
+    {
+        NativeAPI.ReplicateConvar(Slot, conVar, value);
+    }
 }

--- a/managed/CounterStrikeSharp.API/Modules/Extensions/PluginConfigExtensions.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Extensions/PluginConfigExtensions.cs
@@ -7,7 +7,8 @@ public static class PluginConfigExtensions
 {
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
-        WriteIndented = true
+        WriteIndented = true,
+        ReadCommentHandling = JsonCommentHandling.Skip
     };
 
     public static JsonSerializerOptions JsonSerializerOptions => _jsonSerializerOptions;
@@ -62,7 +63,7 @@ public static class PluginConfigExtensions
 
             var configContent = File.ReadAllText(configPath);
 
-            var newConfig = JsonSerializer.Deserialize<T>(configContent)
+            var newConfig = JsonSerializer.Deserialize<T>(configContent, JsonSerializerOptions)
                 ?? throw new JsonException($"Deserialization failed for configuration file '{configPath}'.");
 
             foreach (var property in typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public))

--- a/managed/CounterStrikeSharp.API/Modules/Menu/BaseMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/BaseMenu.cs
@@ -89,7 +89,7 @@ public abstract class BaseMenuInstance : IMenuInstance
     }
 
     protected bool HasPrevButton => Page > 0;
-    protected bool HasNextButton => Menu.MenuOptions.Count > NumPerPage && CurrentOffset + NumPerPage < Menu.MenuOptions.Count;
+    protected virtual bool HasNextButton => Menu.MenuOptions.Count > NumPerPage && CurrentOffset + NumPerPage < Menu.MenuOptions.Count;
     protected bool HasExitButton => Menu.ExitButton;
     protected virtual int MenuItemsPerPage => NumPerPage;
 

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -71,19 +71,16 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
             int count = NumPerPage;
             if (InlinePageOptions == false)
             {
-                if (HasExitButton == false)
+                if (!HasPrevButton)
                     count++;
 
-                if (HasPrevButton == false)
-                    count++;
-
-                if (HasNextButton == false)
+                if (!HasNextButton)
                     count++;
             }
             else
             {
-                count += 2;
-                if (HasExitButton || HasPrevButton || HasNextButton)
+                count++;
+                if (!HasExitButton && !HasPrevButton && !HasNextButton)
                     count++;
             }
 
@@ -125,30 +122,81 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
             builder.AppendLine("<br>");
         }
         
-        if (HasPrevButton)
-        {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.PrevPageColor}'>!7</font> &#60; Prev");
-            if (InlinePageOptions == false)
-                builder.AppendLine("<br>");
-        }
-
-        if (HasNextButton)
-        {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.NextPageColor}'>!8</font> > Next");
-            if (InlinePageOptions == false)
-                builder.AppendLine("<br>");
-        }
-
-        if (centerHtmlMenu.ExitButton)
-        {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.CloseColor}'>!9</font> X Close");
-            if (InlinePageOptions == false)
-                builder.AppendLine("<br>");
-        }
+        AddPageOptions(centerHtmlMenu, builder);
 
         var currentPageText = builder.ToString();
         Player.PrintToCenterHtml(currentPageText);
     }
+    
+    private void AddPageOptions(CenterHtmlMenu centerHtmlMenu, StringBuilder builder)
+    {
+        string prevText = $"<font color='{centerHtmlMenu.PrevPageColor}'>!7 &#60;</font> Prev";
+        string closeText = $"<font color='{centerHtmlMenu.CloseColor}'>!9 X</font> Close";
+        string nextText = $"<font color='{centerHtmlMenu.NextPageColor}'>!8 ></font> Next";
+
+        if (InlinePageOptions)
+            AddInlinePageOptions(prevText, closeText, nextText, centerHtmlMenu.ExitButton, builder);
+        else
+            AddMultilinePageOptions(prevText, closeText, nextText, centerHtmlMenu.ExitButton, builder);
+    }
+
+
+    private void AddInlinePageOptions(string prevText, string closeText, string nextText, bool hasExitButton, StringBuilder builder)
+    {
+        if (HasPrevButton && HasExitButton && HasNextButton)
+        {
+            builder.Append($"{prevText} | {closeText} | {nextText}");
+            return;
+        }
+
+        string doubleOptionSplitString = " \u200e \u200e \u200e \u200e | \u200e \u200e \u200e \u200e "; // empty characters that are not trimmed
+
+        int optionsCount = 0;
+        if (HasPrevButton)
+        {
+            builder.AppendFormat(prevText);
+            optionsCount++;
+        }
+
+        if (hasExitButton)
+        {
+            if (optionsCount++ > 0)
+                builder.Append(doubleOptionSplitString);
+
+            builder.AppendFormat(closeText);
+        }
+
+        if (HasNextButton)
+        {
+            if (optionsCount > 0)
+                builder.Append(doubleOptionSplitString);
+
+            builder.AppendFormat(nextText);
+        }
+    }
+
+    private void AddMultilinePageOptions(string prevText, string closeText, string nextText, bool hasExitButton, StringBuilder builder)
+    {
+        if (HasPrevButton)
+        {
+            builder.AppendFormat(prevText);
+            builder.AppendLine("<br>");
+        }
+
+        if (hasExitButton)
+        {
+            builder.AppendFormat(closeText);
+            builder.AppendLine("<br>");
+        }
+
+        if (HasNextButton)
+        {
+            builder.AppendFormat(nextText);
+            builder.AppendLine("<br>");
+        }
+    }
+    
+    
 
     public override void Close()
     {

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -31,9 +31,9 @@ public class CenterHtmlMenu : BaseMenu
     
     public bool InlinePageOptions { get; set; } = true;
     public int MaxTitleLength { get; set; } = 0; // defaults to 0 = no limit, if enabled, recommended value is 32
-    public int MaxOptionLength  { get; set; }= 0; // defaults to 0 = no limit, if enabled, recommended value is 26
+    public int MaxOptionLength  { get; set; } = 0; // defaults to 0 = no limit, if enabled, recommended value is 26
 
-    public CenterHtmlMenu(string title, BasePlugin plugin, bool inlinePageOptions, int maxTitleLength, int maxOptionLength): base(title)
+    public CenterHtmlMenu(string title, BasePlugin plugin, bool inlinePageOptions = true, int maxTitleLength = 0, int maxOptionLength = 0): base(title)
     {
         Title = title.TruncateHtml(MaxTitleLength);
         _plugin = plugin;

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -63,7 +63,33 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
 {
     private readonly BasePlugin _plugin;
     public override int NumPerPage => 5; // one less than the actual number of items per page to avoid truncated options
-    protected override int MenuItemsPerPage => (Menu.ExitButton ? 0 : 1) + ((HasPrevButton && HasNextButton) ? NumPerPage - 1 : NumPerPage);
+    public bool InlinePageOptions => CoreConfig.InlinePageOptions;
+    protected override int MenuItemsPerPage
+    {
+        get
+        {
+            int count = NumPerPage;
+            if (InlinePageOptions == false)
+            {
+                if (HasExitButton == false)
+                    count++;
+
+                if (HasPrevButton == false)
+                    count++;
+
+                if (HasNextButton == false)
+                    count++;
+            }
+            else
+            {
+                count += 2;
+                if (HasExitButton || HasPrevButton || HasNextButton)
+                    count++;
+            }
+
+            return count;
+        }
+    }
 
     public CenterHtmlMenuInstance(BasePlugin plugin, CCSPlayerController player, IMenu menu) : base(player, menu)
     {
@@ -98,23 +124,26 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
             builder.Append($"<font color='{color}'>!{keyOffset++}</font> {option.Text}");
             builder.AppendLine("<br>");
         }
-
+        
         if (HasPrevButton)
         {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.PrevPageColor}'>!7</font> &#60;- Prev");
-            builder.AppendLine("<br>");
+            builder.AppendFormat($"<font color='{centerHtmlMenu.PrevPageColor}'>!7</font> &#60; Prev");
+            if (InlinePageOptions == false)
+                builder.AppendLine("<br>");
         }
 
         if (HasNextButton)
         {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.NextPageColor}'>!8</font> -> Next");
-            builder.AppendLine("<br>");
+            builder.AppendFormat($"<font color='{centerHtmlMenu.NextPageColor}'>!8</font> > Next");
+            if (InlinePageOptions == false)
+                builder.AppendLine("<br>");
         }
 
         if (centerHtmlMenu.ExitButton)
         {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.CloseColor}'>!9</font> -> Close");
-            builder.AppendLine("<br>");
+            builder.AppendFormat($"<font color='{centerHtmlMenu.CloseColor}'>!9</font> X Close");
+            if (InlinePageOptions == false)
+                builder.AppendLine("<br>");
         }
 
         var currentPageText = builder.ToString();

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -72,6 +72,7 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
 {
     private readonly BasePlugin _plugin;
     public override int NumPerPage => 5; // one less than the actual number of items per page to avoid truncated options
+    protected override bool HasNextButton => Menu.MenuOptions.Count > NumPerPage + 1 && CurrentOffset + NumPerPage < Menu.MenuOptions.Count;
     public bool InlinePageOptions { get; set; } = true;
     protected override int MenuItemsPerPage
     {

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -195,15 +195,15 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
             builder.AppendLine("<br>");
         }
 
-        if (hasExitButton)
-        {
-            builder.AppendFormat(closeText);
-            builder.AppendLine("<br>");
-        }
-
         if (HasNextButton)
         {
             builder.AppendFormat(nextText);
+            builder.AppendLine("<br>");
+        }
+        
+        if (hasExitButton)
+        {
+            builder.AppendFormat(closeText);
             builder.AppendLine("<br>");
         }
     }

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -28,15 +28,24 @@ public class CenterHtmlMenu : BaseMenu
     public string PrevPageColor { get; set; } = "yellow";
     public string NextPageColor { get; set; } = "yellow";
     public string CloseColor { get; set; } = "red";
+    
+    public bool InlinePageOptions { get; set; } = true;
+    public int MaxTitleLength { get; set; } = 0; // defaults to 0 = no limit, if enabled, recommended value is 32
+    public int MaxOptionLength  { get; set; }= 0; // defaults to 0 = no limit, if enabled, recommended value is 26
 
-    public CenterHtmlMenu(string title, BasePlugin plugin) : base(title.TruncateHtmlTitle())
+    public CenterHtmlMenu(string title, BasePlugin plugin, bool inlinePageOptions, int maxTitleLength, int maxOptionLength): base(title)
     {
+        Title = title.TruncateHtml(MaxTitleLength);
         _plugin = plugin;
+        InlinePageOptions = inlinePageOptions;
+        MaxTitleLength = maxTitleLength;
+        MaxOptionLength = maxOptionLength;
     }
 
     [Obsolete("Use the constructor that takes a BasePlugin")]
-    public CenterHtmlMenu(string title) : base(title.TruncateHtmlTitle())
+    public CenterHtmlMenu(string title) : base(title)
     {
+        Title = title.TruncateHtml(MaxTitleLength);
     }
 
     public override void Open(CCSPlayerController player)
@@ -53,7 +62,7 @@ public class CenterHtmlMenu : BaseMenu
     public override ChatMenuOption AddMenuOption(string display, Action<CCSPlayerController, ChatMenuOption> onSelect,
         bool disabled = false)
     {
-        var option = new ChatMenuOption(display.TruncateHtmlOption(), disabled, onSelect);
+        var option = new ChatMenuOption(display.TruncateHtml(MaxOptionLength), disabled, onSelect);
         MenuOptions.Add(option);
         return option;
     }
@@ -63,7 +72,7 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
 {
     private readonly BasePlugin _plugin;
     public override int NumPerPage => 5; // one less than the actual number of items per page to avoid truncated options
-    public bool InlinePageOptions => CoreConfig.InlinePageOptions;
+    public bool InlinePageOptions { get; set; } = true;
     protected override int MenuItemsPerPage
     {
         get
@@ -93,6 +102,9 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
         _plugin = plugin;
         RemoveOnTickListener();
         plugin.RegisterListener<Core.Listeners.OnTick>(Display);
+        
+        if (menu is CenterHtmlMenu centerHtmlMenu)
+            InlinePageOptions = centerHtmlMenu.InlinePageOptions;
     }
 
     public override void Display()

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -29,13 +29,13 @@ public class CenterHtmlMenu : BaseMenu
     public string NextPageColor { get; set; } = "yellow";
     public string CloseColor { get; set; } = "red";
 
-    public CenterHtmlMenu(string title, BasePlugin plugin) : base(title)
+    public CenterHtmlMenu(string title, BasePlugin plugin) : base(title.TruncateHtmlTitle())
     {
         _plugin = plugin;
     }
 
     [Obsolete("Use the constructor that takes a BasePlugin")]
-    public CenterHtmlMenu(string title) : base(title)
+    public CenterHtmlMenu(string title) : base(title.TruncateHtmlTitle())
     {
     }
 
@@ -53,7 +53,7 @@ public class CenterHtmlMenu : BaseMenu
     public override ChatMenuOption AddMenuOption(string display, Action<CCSPlayerController, ChatMenuOption> onSelect,
         bool disabled = false)
     {
-        var option = new ChatMenuOption(display, disabled, onSelect);
+        var option = new ChatMenuOption(display.TruncateHtmlOption(), disabled, onSelect);
         MenuOptions.Add(option);
         return option;
     }

--- a/managed/CounterStrikeSharp.API/Modules/Menu/MenuManager.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/MenuManager.cs
@@ -52,7 +52,6 @@ public static class MenuManager
     
     public static void OpenCenterHtmlMenu(BasePlugin plugin, CCSPlayerController player, CenterHtmlMenu menu)
     {
-        
         CloseActiveMenu(player);
         
         ActiveMenus[player.Handle] = new CenterHtmlMenuInstance(plugin, player, menu);

--- a/managed/CounterStrikeSharp.API/Modules/Menu/MenuManager.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/MenuManager.cs
@@ -52,6 +52,7 @@ public static class MenuManager
     
     public static void OpenCenterHtmlMenu(BasePlugin plugin, CCSPlayerController player, CenterHtmlMenu menu)
     {
+        
         CloseActiveMenu(player);
         
         ActiveMenus[player.Handle] = new CenterHtmlMenuInstance(plugin, player, menu);

--- a/managed/CounterStrikeSharp.API/StringExtensions.cs
+++ b/managed/CounterStrikeSharp.API/StringExtensions.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CounterStrikeSharp.API
+{
+	public static class StringExtensions
+	{
+		private const string HTML_TAG_REGEX_PATTERN = "<[^>]+>";
+		private static readonly Regex TagRegex = new(HTML_TAG_REGEX_PATTERN, RegexOptions.Compiled);
+
+		public static string TruncateHtmlTitle(this string msg)
+		{
+			int titleMaxLength = CoreConfig.MaxHtmlMenuTitleLength;
+			return TruncateHtml(msg, titleMaxLength);
+		}
+
+		public static string TruncateHtmlOption(this string msg)
+		{
+			int titleMaxLength = CoreConfig.MaxHtmlMenuOptionLength;
+			return TruncateHtml(msg, titleMaxLength);
+		}
+
+		public static string TruncateHtml(this string msg, int maxLength)
+		{
+			if (maxLength <= 0)
+				return msg;
+
+			if (string.IsNullOrEmpty(msg))
+				return string.Empty;
+
+			string textOnly = Regex.Replace(msg, HTML_TAG_REGEX_PATTERN, "");
+			if (textOnly.Length <= maxLength)
+				return msg;
+
+			Stack<string> tagStack = new Stack<string>();
+			StringBuilder result = new System.Text.StringBuilder();
+			int visibleLength = 0,
+				i = 0;
+
+			while (i < msg.Length && visibleLength < maxLength)
+			{
+				if (msg[i] == '<')
+				{
+					Match match = TagRegex.Match(msg, i);
+					if (match.Success && match.Index == i)
+					{
+						string tag = match.Value;
+						result.Append(tag);
+						i += tag.Length;
+
+						if (!tag.StartsWith("</")) // Opening tag
+						{
+							string tagName = tag.Split(new[] { ' ', '>' }, StringSplitOptions.RemoveEmptyEntries)[0].Trim('<');
+							if (!tag.EndsWith("/>") && !tagName.StartsWith("!"))
+								tagStack.Push(tagName);
+						}
+						else if (tagStack.Count > 0)
+						{
+							tagStack.Pop();
+						}
+
+						continue;
+					}
+				}
+				else
+				{
+					result.Append(msg[i]);
+					visibleLength++;
+				}
+
+				i++;
+			}
+
+			while (tagStack.Count > 0)
+				result.Append($"</{tagStack.Pop()}>");
+
+			return result.ToString();
+		}
+	}
+}

--- a/managed/CounterStrikeSharp.API/StringExtensions.cs
+++ b/managed/CounterStrikeSharp.API/StringExtensions.cs
@@ -7,19 +7,7 @@ namespace CounterStrikeSharp.API
 	{
 		private const string HTML_TAG_REGEX_PATTERN = "<[^>]+>";
 		private static readonly Regex TagRegex = new(HTML_TAG_REGEX_PATTERN, RegexOptions.Compiled);
-
-		public static string TruncateHtmlTitle(this string msg)
-		{
-			int titleMaxLength = CoreConfig.MaxHtmlMenuTitleLength;
-			return TruncateHtml(msg, titleMaxLength);
-		}
-
-		public static string TruncateHtmlOption(this string msg)
-		{
-			int titleMaxLength = CoreConfig.MaxHtmlMenuOptionLength;
-			return TruncateHtml(msg, titleMaxLength);
-		}
-
+		
 		public static string TruncateHtml(this string msg, int maxLength)
 		{
 			if (maxLength <= 0)

--- a/src/scripting/natives/natives_commands.yaml
+++ b/src/scripting/natives/natives_commands.yaml
@@ -13,3 +13,4 @@ FIND_CONVAR: name:string -> pointer
 SET_CONVAR_STRING_VALUE: convar:pointer,value:string -> void
 GET_CLIENT_CONVAR_VALUE: clientIndex:int,convarName:string -> string
 SET_FAKE_CLIENT_CONVAR_VALUE: clientIndex:int,convarName:string,convarValue:string -> void
+REPLICATE_CONVAR: clientSlot:int,convarName:string,convarValue:string -> void


### PR DESCRIPTION
Following up with #758 

The features are:
- Added an option in `CenterHtmlMenu` to have automated Title and Option max length.
- Improved automated max length tu fully support HTML tags
- Added an option int `CenterHtmlMenu` to inline the pagination options Prev/Next/Close.
- Fixed a bug where a `CenterHtmlMenu` with 7 options would have 2 pages, the second one being empty.

Usage:
`CenterHtmlMenu menu = new CenterHtmlMenu("Test Very Long Title Menu", this, inlinePageOptions: true, maxTitleLength: 32, maxOptionLength: 26);`

Info:
- All 4 new parameters in the constructor are optional for retro-compatibility
- `inlinePageOptions` defaults to true.
- `maxTitleLength` and `maxOptionLength` both default to 0. 0 = no max length.