### PR TITLE
feat: Expose `MetaFactory` to API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SOURCE_FILES
     src/scripting/natives/natives_schema.cpp
     src/scripting/natives/natives_entities.cpp
     src/scripting/natives/natives_voice.cpp
+    src/scripting/natives/natives_metamod.cpp
     src/core/managers/entity_manager.cpp
     src/core/managers/entity_manager.h
     src/core/managers/chat_manager.cpp

--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -1172,6 +1172,17 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+        public static IntPtr MetaFactory(string interfacename){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.Push(interfacename);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x61521EF3);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			}
+		}
+
         public static short GetSchemaOffset(string classname, string propname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();

--- a/managed/CounterStrikeSharp.API/Core/GameEvents.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/GameEvents.g.cs
@@ -4489,14 +4489,6 @@ namespace CounterStrikeSharp.API.Core
                 }
 
 
-                // ip:port
-                public string Address
-                {
-                    get => Get<string>("address");
-                    set => Set<string>("address", value);
-                }
-
-
                 
                 public bool Bot
                 {

--- a/managed/CounterStrikeSharp.API/Core/Listeners.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Listeners.g.cs
@@ -170,5 +170,11 @@ namespace CounterStrikeSharp.API.Core
         /// <param name="infoList">Transmit info list</param>
         [ListenerName("CheckTransmit")]
         public delegate void CheckTransmit([CastFrom(typeof(nint))]CCheckTransmitInfoList infoList);
+
+        /// <summary>
+        /// Called when all metamod plugins are loaded.
+        /// </summary>
+        [ListenerName("OnMetamodAllPluginsLoaded")]
+        public delegate void OnMetamodAllPluginsLoaded();
     }
 }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -247,5 +247,19 @@ namespace CounterStrikeSharp.API
             entity.LastNetworkChange = Server.CurrentTime;
             entity.IsSteadyState.Clear();
         }
+
+        /// <summary>
+        /// metamod method 'MetaFactory' to get the pointer of api interface exposed by metamod plugins.
+        /// Returns null when the interface cannot be found.
+        /// <param name="interfaceName">The interface name of metamod api, can be found in their api header file</param>
+        public static IntPtr? MetaFactory(string interfaceName)
+        {
+            IntPtr ptr = NativeAPI.MetaFactory(interfaceName);
+            if (ptr == 0)
+            {
+                return null;
+            }
+            return ptr;
+        }
     }
 }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -251,6 +251,7 @@ namespace CounterStrikeSharp.API
         /// <summary>
         /// metamod method 'MetaFactory' to get the pointer of api interface exposed by metamod plugins.
         /// Returns null when the interface cannot be found.
+        /// </summary>
         /// <param name="interfaceName">The interface name of metamod api, can be found in their api header file</param>
         public static IntPtr? MetaFactory(string interfaceName)
         {

--- a/src/mm_plugin.cpp
+++ b/src/mm_plugin.cpp
@@ -134,6 +134,7 @@ bool CounterStrikeSharpMMPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, s
     CALL_GLOBAL_LISTENER(OnAllInitialized());
 
     on_activate_callback = globals::callbackManager.CreateCallback("OnMapStart");
+    on_metamod_all_plugins_loaded_callback = globals::callbackManager.CreateCallback("OnMetamodAllPluginsLoaded");
 
     SH_ADD_HOOK_MEMFUNC(IServerGameDLL, GameFrame, globals::server, this, &CounterStrikeSharpMMPlugin::Hook_GameFrame, true);
     SH_ADD_HOOK_MEMFUNC(INetworkServerService, StartupServer, globals::networkServerService, this,
@@ -182,6 +183,7 @@ bool CounterStrikeSharpMMPlugin::Unload(char* error, size_t maxlen)
                            &CounterStrikeSharpMMPlugin::Hook_StartupServer, true);
 
     globals::callbackManager.ReleaseCallback(on_activate_callback);
+    globals::callbackManager.ReleaseCallback(on_metamod_all_plugins_loaded_callback);
 
     return true;
 }
@@ -191,6 +193,8 @@ void CounterStrikeSharpMMPlugin::AllPluginsLoaded()
     /* This is where we'd do stuff that relies on the mod or other plugins
      * being initialized (for example, cvars added and events registered).
      */
+    on_metamod_all_plugins_loaded_callback->ScriptContext().Reset();
+    on_metamod_all_plugins_loaded_callback->Execute();
 }
 
 void CounterStrikeSharpMMPlugin::AddTaskForNextFrame(std::function<void()>&& task)

--- a/src/mm_plugin.h
+++ b/src/mm_plugin.h
@@ -71,6 +71,7 @@ class CounterStrikeSharpMMPlugin : public ISmmPlugin, public IMetamodListener
 };
 
 static ScriptCallback* on_activate_callback;
+static ScriptCallback* on_metamod_all_plugins_loaded_callback;
 extern CounterStrikeSharpMMPlugin gPlugin;
 
 PLUGIN_GLOBALVARS();

--- a/src/scripting/listeners/metamod.yaml
+++ b/src/scripting/listeners/metamod.yaml
@@ -1,0 +1,1 @@
+OnMetamodAllPluginsLoaded:

--- a/src/scripting/natives/natives_metamod.cpp
+++ b/src/scripting/natives/natives_metamod.cpp
@@ -1,0 +1,32 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
+ */
+
+#include <scripting/autonative.h>
+#include <scripting/script_engine.h>
+
+namespace counterstrikesharp {
+
+static void* MetaFactory(ScriptContext& script_context)
+{
+    auto interfaceName = script_context.GetArgument<const char*>(0);
+    void* ptr = globals::ismm->MetaFactory(interfaceName, nullptr, nullptr);
+    return ptr;
+}
+
+REGISTER_NATIVES(metamod, {
+    ScriptEngine::RegisterNativeHandler("META_FACTORY", MetaFactory);
+})
+} // namespace counterstrikesharp

--- a/src/scripting/natives/natives_metamod.yaml
+++ b/src/scripting/natives/natives_metamod.yaml
@@ -1,0 +1,1 @@
+META_FACTORY: interfaceName:string -> pointer


### PR DESCRIPTION
This PR can expose the function `MetaFactory` and the listener `AllPluginsLoaded` in metamod to the cssharp API, which enable user to have a basic way to interact with metamod plugins without using p/invoke.

## Added
- NativeAPI: `IntPtr NativeAPI.MetaFactory(pInterfaceName);`
- Utilities: `IntPtr? Utilities.MetaFactory(pInterfaceName);`
- Listener: `Listeners.OnMetamodAllPluginsLoaded`

## Usage
Here's an example usage:
```csharp
RegisterListener<Listeners.OnMetamodAllPluginsLoaded>(() => {
    nint? pMultiAddonManager = Utilities.MetaFactory("MultiAddonManager002");
    if (!pMultiAddonManager.HasValue) {
        Console.WriteLine("Multiaddonmanager not installed!");
        return;
    }
    var RefreshAddons = VirtualFunction.CreateVoid<IntPtr>(pMultiAddonManager.Value, 4);
    RefreshAddons.Invoke(pMultiAddonManager.Value);
});
```