### PR TITLE
fix: Remove requirement for https for game config updates

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
             "label": "build",
             "type": "shell",
             "group": "build",
-            "command": "cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build build -j$(nproc)",
+            "command": "cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)",
         },
         {
             "label": "build-api",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,6 @@ project(counterstrikesharp C CXX ASM)
 
 include("makefiles/shared.cmake")
 
-# Find OpenSSL for httplib SSL support
-find_package(OpenSSL REQUIRED)
-
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 add_subdirectory(libraries/spdlog)

--- a/makefiles/linux.base.cmake
+++ b/makefiles/linux.base.cmake
@@ -29,6 +29,4 @@ set(
     distorm
     funchook-static
     dynohook
-    OpenSSL::SSL
-    OpenSSL::Crypto
 )

--- a/makefiles/windows.base.cmake
+++ b/makefiles/windows.base.cmake
@@ -19,6 +19,4 @@ set(COUNTER_STRIKE_SHARP_LINK_LIBRARIES
     distorm
     funchook-static
     dynohook
-    OpenSSL::SSL
-    OpenSSL::Crypto
 )

--- a/src/core/coreconfig.h
+++ b/src/core/coreconfig.h
@@ -36,7 +36,7 @@ class CCoreConfig
     bool UnlockConCommands = true;
     bool UnlockConVars = true;
     bool AutoUpdateEnabled = true;
-    std::string AutoUpdateURL = std::string("https://gamedata.cssharp.dev");
+    std::string AutoUpdateURL = std::string("http://gamedata.cssharp.dev");
 
     using json = nlohmann::json;
     CCoreConfig(const std::string& path);

--- a/src/core/gameconfig_updater.cpp
+++ b/src/core/gameconfig_updater.cpp
@@ -8,7 +8,6 @@
 #include <fstream>
 #include <filesystem>
 
-#define CPPHTTPLIB_OPENSSL_SUPPORT
 #include "httplib/httplib.h"
 
 namespace counterstrikesharp::update {
@@ -20,6 +19,8 @@ namespace counterstrikesharp::update {
 /// @return
 bool TryUpdateGameConfig()
 {
+    CSSHARP_CORE_INFO("AutoUpdate enabled, checking for gamedata updates from {}", globals::coreConfig->AutoUpdateURL);
+
     auto gamedata_path = std::string(utils::GamedataDirectory() + "/gamedata.json");
     auto etag_path = std::string(utils::GamedataDirectory() + "/gamedata.etag");
 

--- a/src/mm_plugin.cpp
+++ b/src/mm_plugin.cpp
@@ -120,8 +120,6 @@ bool CounterStrikeSharpMMPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, s
 
     if (globals::coreConfig->AutoUpdateEnabled)
     {
-        CSSHARP_CORE_INFO("AutoUpdate enabled, checking for gamedata updates...");
-
         if (!update::TryUpdateGameConfig())
         {
             CSSHARP_CORE_ERROR("Failed to update game config.");


### PR DESCRIPTION
The CDN has been updated to not force https redirect, and we no longer link against libssl