### PR TITLE
feat: add Vector3 and QAngle explicit casts to System.Numerics.Vector3

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
@@ -16,7 +16,7 @@ public partial class CBaseEntity
         Guard.IsValidEntity(this);
 
         if (position == null && angles == null && velocity == null)
-            throw new ArgumentNullException("No valid argument");
+            throw new ArgumentException("At least one parameter must be specified");
 
         nint _position = position?.Handle ?? 0;
         nint _angles = angles?.Handle ?? 0;
@@ -27,7 +27,12 @@ public partial class CBaseEntity
             _angles, _velocity);
     }
 
-    /// <inheritdoc cref="Teleport(Vector?, QAngle?, Vector?)"/>
+    /// <summary>
+    /// Teleports the entity to the specified position, angles, and velocity using Vector3 parameters.
+    /// This overload is optimized for memory efficiency by directly working with a Vector3 struct.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Entity is not valid</exception>
+    /// <exception cref="ArgumentNullException">No valid argument</exception>
     public void Teleport(Vector3? position = null, Vector3? angles = null, Vector3? velocity = null)
     {
         Guard.IsValidEntity(this);

--- a/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
@@ -42,7 +42,7 @@ public partial class CBaseEntity
             if (position.HasValue)
             {
                 var pos = position.Value;
-                positionPtr = &position;
+                positionPtr = &pos;
             }
 
             if (angles.HasValue)

--- a/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using CounterStrikeSharp.API.Modules.Memory;
 using CounterStrikeSharp.API.Modules.Utils;
+using Vector = CounterStrikeSharp.API.Modules.Utils.Vector;
 
 namespace CounterStrikeSharp.API.Core;
 
@@ -23,6 +25,42 @@ public partial class CBaseEntity
 
         VirtualFunction.CreateVoid<IntPtr, IntPtr, IntPtr, IntPtr>(_handle, GameData.GetOffset("CBaseEntity_Teleport"))(_handle, _position,
             _angles, _velocity);
+    }
+
+    /// <inheritdoc cref="Teleport(Vector?, QAngle?, Vector?)"/>
+    public void Teleport(Vector3? position = null, Vector3? angles = null, Vector3? velocity = null)
+    {
+        Guard.IsValidEntity(this);
+
+        if (position == null && angles == null && velocity == null)
+            throw new ArgumentNullException("No valid argument");
+
+        unsafe
+        {
+            void* positionPtr = null, anglePtr = null, velocityPtr = null;
+
+            if (position.HasValue)
+            {
+                var pos = position.Value;
+                positionPtr = &position;
+            }
+
+            if (angles.HasValue)
+            {
+                var ang = angles.Value;
+                anglePtr = &ang;
+            }
+
+            if (velocity.HasValue)
+            {
+                var vel = velocity.Value;
+                velocityPtr = &vel;
+            }
+
+            VirtualFunction.CreateVoid<IntPtr, IntPtr, IntPtr, IntPtr>(Handle, GameData.GetOffset("CBaseEntity_Teleport"))(Handle,
+                (nint)positionPtr,
+                (nint)anglePtr, (nint)velocityPtr);
+        }
     }
 
     /// <exception cref="InvalidOperationException">Entity is not valid</exception>
@@ -62,7 +100,7 @@ public partial class CBaseEntity
     public uint EmitSound(string soundEventName, RecipientFilter? recipients = null, float volume = 1f, float pitch = 0)
     {
         Guard.IsValidEntity(this);
-        
+
         if (recipients == null)
         {
             recipients = new RecipientFilter();

--- a/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
@@ -10,7 +10,7 @@ namespace CounterStrikeSharp.API.Core;
 public partial class CBaseEntity
 {
     /// <exception cref="InvalidOperationException">Entity is not valid</exception>
-    /// <exception cref="ArgumentNullException">No valid argument</exception>
+    /// <exception cref="ArgumentNullException">At least one parameter must be specified</exception>
     public void Teleport(Vector? position = null, QAngle? angles = null, Vector? velocity = null)
     {
         Guard.IsValidEntity(this);
@@ -32,13 +32,13 @@ public partial class CBaseEntity
     /// This overload is optimized for memory efficiency by directly working with a Vector3 struct.
     /// </summary>
     /// <exception cref="InvalidOperationException">Entity is not valid</exception>
-    /// <exception cref="ArgumentNullException">No valid argument</exception>
+    /// <exception cref="ArgumentException">At least one parameter must be specified</exception>
     public void Teleport(Vector3? position = null, Vector3? angles = null, Vector3? velocity = null)
     {
         Guard.IsValidEntity(this);
 
         if (position == null && angles == null && velocity == null)
-            throw new ArgumentNullException("No valid argument");
+            throw new ArgumentException("At least one parameter must be specified");
 
         unsafe
         {

--- a/managed/CounterStrikeSharp.API/Modules/Utils/QAngle.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Utils/QAngle.cs
@@ -47,6 +47,11 @@ namespace CounterStrikeSharp.API.Modules.Utils
         {
             unsafe
             {
+                if (q is null)
+                {
+                    throw new ArgumentNullException(nameof(q), "Input QAngle cannot be null.");
+                }
+
                 return new Vector3(new ReadOnlySpan<float>(q.Handle.ToPointer(), 3));
             }
         }

--- a/managed/CounterStrikeSharp.API/Modules/Utils/QAngle.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Utils/QAngle.cs
@@ -14,6 +14,7 @@
  *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
  */
 
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace CounterStrikeSharp.API.Modules.Utils
@@ -21,11 +22,11 @@ namespace CounterStrikeSharp.API.Modules.Utils
     public class QAngle : NativeObject
     {
         public static readonly QAngle Zero = new();
-        
+
         public QAngle(IntPtr pointer) : base(pointer)
         {
         }
-        
+
         public QAngle(float? x = null, float? y = null, float? z = null) : this(NativeAPI.AngleNew())
         {
             this.X = x ?? 0;
@@ -36,10 +37,18 @@ namespace CounterStrikeSharp.API.Modules.Utils
         public unsafe ref float X => ref Unsafe.Add(ref *(float*)Handle.ToPointer(), 0);
         public unsafe ref float Y => ref Unsafe.Add(ref *(float*)Handle, 1);
         public unsafe ref float Z => ref Unsafe.Add(ref *(float*)Handle, 2);
-        
+
         public override string ToString()
         {
             return $"{X:n2} {Y:n2} {Z:n2}";
+        }
+
+        public static explicit operator Vector3(QAngle q)
+        {
+            unsafe
+            {
+                return new Vector3(new ReadOnlySpan<float>(q.Handle.ToPointer(), 3));
+            }
         }
     }
 }

--- a/managed/CounterStrikeSharp.API/Modules/Utils/Vector.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Utils/Vector.cs
@@ -297,6 +297,7 @@ namespace CounterStrikeSharp.API.Modules.Utils
             NativePINVOKE.Vector_Zero(ptr);
         }
         */
+
         #region Operators
 
         public float this[int i]
@@ -351,12 +352,22 @@ namespace CounterStrikeSharp.API.Modules.Utils
         {
             return new Vector(a.X * b, a.Y * b, a.Z * b);
         }
+
         public static Vector operator /(Vector a, float b)
         {
             return new Vector(a.X / b, a.Y / b, a.Z / b);
         }
 
+        public static explicit operator Vector3(Vector v)
+        {
+            unsafe
+            {
+                return new Vector3(new ReadOnlySpan<float>(v.Handle.ToPointer(), 3));
+            }
+        }
+
         #endregion
+
         /*
 
         public override bool Equals(object obj)

--- a/managed/CounterStrikeSharp.API/Modules/Utils/Vector.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Utils/Vector.cs
@@ -362,6 +362,11 @@ namespace CounterStrikeSharp.API.Modules.Utils
         {
             unsafe
             {
+                if (v is null)
+                {
+                    throw new ArgumentNullException(nameof(v), "Input Vector cannot be null.");
+                }
+
                 return new Vector3(new ReadOnlySpan<float>(v.Handle.ToPointer(), 3));
             }
         }


### PR DESCRIPTION
Since `Teleport` is probably the biggest source of Vector based memory leaks, this adds a way to call the Teleport virtual method using `System.Numerics.Vector3` while still maintaining backwards compatibility.

To increase the ergonomics of modifying existing vectors coming out of the schema system (like with AbsOrigin), I've added explicit cast operators to allow you to easily convert to a numerics Vector3. This means the following code can be substituted to remove memory leak:

Before:
```cs
// Leaks because 2021 Roflmuffin sucks and `new Vector` allocates memory in native side and never frees it
pawn.Teleport(new Vector(pawn.AbsOrigin.X, pawn.AbsOrigin.Y, pawn.AbsOrigin.Z + 100));
```

After:
```cs
// Doesn't leak because the Vector3 is a struct and the pointer passed directly to native and GCd/freed by C# after
pawn.Teleport((Vector3)pawn.AbsOrigin with { Z = pawn.AbsOrigin.Z + 100 });
```

Unfortunately to ultimately fix memory leaks with regards to the schema system, it will require breaking changes so this will need to be done in a breaking 2.0 release of CS# I imagine.