### PR TITLE
feat: add `OnPlayerChat` listener

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Listeners.g.cs
+++ b/managed/CounterStrikeSharp.API/Core/Listeners.g.cs
@@ -192,6 +192,16 @@ namespace CounterStrikeSharp.API.Core
         [ListenerName("OnPlayerButtonsChanged")]
         public delegate void OnPlayerButtonsChanged(CCSPlayerController player, PlayerButtons pressed, PlayerButtons released);
 
+
+        /// <summary>
+        /// Called when a player sends a chat message.
+        /// </summary>
+        /// <param name="player">The player who sent the chat message.</param>
+        /// <param name="message">The content of the chat message.</param>
+        /// <param name="teamChat">If the chat message was sent to team only.</param>
+        [ListenerName("OnPlayerChat")]
+        public delegate void OnPlayerChat(CCSPlayerController player, string message, bool teamChat);
+
         /// <summary>
         /// Called when all metamod plugins are loaded.
         /// </summary>

--- a/src/core/managers/chat_manager.h
+++ b/src/core/managers/chat_manager.h
@@ -55,6 +55,8 @@ class ChatManager : public GlobalClass
     bool OnSayCommandPre(CEntityInstance* pController, CCommand& args);
     void OnSayCommandPost(CEntityInstance* pController, CCommand& args);
 
+    ScriptCallback* on_player_chat_callback = nullptr;
+
   private:
     void InternalDispatch(CEntityInstance* pPlayerController, const char* szTriggerPhrase, CCommand& pFullCommand);
 


### PR DESCRIPTION
Replaces the old `player_chat` hacky game event with an actual listener so we aren't tied to valve game events.