### PR TITLE
[Experimental] NuGet Dependency Resolver for Plugins

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
+++ b/managed/CounterStrikeSharp.API/Core/CoreConfig.cs
@@ -53,6 +53,9 @@ namespace CounterStrikeSharp.API.Core
         [JsonPropertyName("PluginAutoLoadEnabled")]
         public bool PluginAutoLoadEnabled { get; set; } = true;
 
+        [JsonPropertyName("UseExperimentalPluginDependencyResolver")]
+        public bool UseExperimentalPluginDependencyResolver { get; set; }
+
         [JsonPropertyName("ServerLanguage")]
         public string ServerLanguage { get; set; } = "en";
 
@@ -114,6 +117,8 @@ namespace CounterStrikeSharp.API.Core
         /// When enabled, plugins are automatically loaded from the plugins directory on server start.
         /// </summary>
         public static bool PluginAutoLoadEnabled => _coreConfig.PluginAutoLoadEnabled;
+
+        public static bool UseExperimentalPluginDependencyResolver => _coreConfig.UseExperimentalPluginDependencyResolver;
 
         public static string ServerLanguage => _coreConfig.ServerLanguage;
 

--- a/managed/CounterStrikeSharp.API/Core/Plugin/Host/IPluginContextDependencyResolver.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/Host/IPluginContextDependencyResolver.cs
@@ -1,0 +1,6 @@
+﻿namespace CounterStrikeSharp.API.Core.Plugin.Host;
+
+public interface IPluginContextDependencyResolver
+{
+    public string? ResolvePath();
+}

--- a/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginContextNuGetDependencyResolver.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginContextNuGetDependencyResolver.cs
@@ -1,0 +1,93 @@
+﻿using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
+
+namespace CounterStrikeSharp.API.Core.Plugin.Host;
+
+public class PluginContextNuGetDependencyResolver : IPluginContextDependencyResolver
+{
+    private const string NuGetPackagesEnvName = "NUGET_PACKAGES";
+
+    private readonly string _rootAssemblyName;
+    private readonly string _rootAssemblyPath;
+    private readonly AssemblyName _assemblyName;
+
+    public PluginContextNuGetDependencyResolver(string rootAssemblyName,
+        string rootAssemblyPath,
+        AssemblyName assemblyName)
+    {
+        _rootAssemblyName = rootAssemblyName;
+        _rootAssemblyPath = rootAssemblyPath;
+        _assemblyName = assemblyName;
+    }
+
+    public string? ResolvePath()
+    {
+        var packagesRoot = GetNuGetPackagesRoot();
+        if (string.IsNullOrWhiteSpace(packagesRoot))
+        {
+            return null;
+        }
+
+        var packageName = _assemblyName.Name;
+        if (string.IsNullOrWhiteSpace(packageName))
+        {
+            return null;
+        }
+
+        var dependenciesPath = Path.Combine(_rootAssemblyPath, $"{_rootAssemblyName}.deps.json");
+        if (!File.Exists(dependenciesPath))
+        {
+            return null;
+        }
+
+        using var dependenciesStream = File.OpenRead(dependenciesPath);
+
+        using var dependencyReader = new DependencyContextJsonReader();
+        var context = dependencyReader.Read(dependenciesStream);
+
+        var dependencyPath = string.Empty;
+        foreach (var dependency in context.RuntimeLibraries)
+        {
+            if (dependency.Name == packageName)
+            {
+                if (string.IsNullOrWhiteSpace(dependency.Path) || !dependency.RuntimeAssemblyGroups.Any())
+                {
+                    return null;
+                }
+
+                var runtimeAssemblyGroup = dependency.RuntimeAssemblyGroups[0];
+                if (!runtimeAssemblyGroup.AssetPaths.Any())
+                {
+                    return null;
+                }
+
+                dependencyPath = Path.Combine(dependency.Path, runtimeAssemblyGroup.AssetPaths[0]);
+                break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(dependencyPath))
+        {
+            return null;
+        }
+
+        return Path.Combine(packagesRoot, dependencyPath);
+    }
+
+    private static string? GetNuGetPackagesRoot()
+    {
+        var nugetPath = Environment.GetEnvironmentVariable(NuGetPackagesEnvName);
+        if (!string.IsNullOrWhiteSpace(nugetPath) && Directory.Exists(nugetPath))
+        {
+            return nugetPath;
+        }
+
+        var userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(userProfilePath))
+        {
+            return null;
+        }
+
+        return Path.Combine(userProfilePath, ".nuget", "packages");
+    }
+}

--- a/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -36,6 +37,17 @@ public class PluginManager : IPluginManager
             config => { config.PreferSharedTypes = true; });
         var assembly = loader.LoadDefaultAssembly();
 
+        if (CoreConfig.UseExperimentalPluginDependencyResolver)
+        {
+            foreach (var assemblyName in assembly.GetReferencedAssemblies())
+            {
+                if (TryLoadDependency(path, assembly.GetName().Name, assemblyName, out var dependency))
+                {
+                    _sharedAssemblies.TryAdd(dependency.GetName().Name, dependency);
+                }
+            }
+        }
+
         _sharedAssemblies[assembly.GetName().Name] = assembly;
     }
 
@@ -46,7 +58,7 @@ public class PluginManager : IPluginManager
             .Select(dir => Path.Combine(dir, Path.GetFileName(dir) + ".dll"))
             .Where(File.Exists)
             .ToArray();
-        
+
         foreach (var sharedAssemblyPath in sharedAssemblyPaths)
         {
             try
@@ -78,6 +90,11 @@ public class PluginManager : IPluginManager
 
             if (!_sharedAssemblies.TryGetValue(name.Name, out var assembly))
             {
+                if (CoreConfig.UseExperimentalPluginDependencyResolver && TryLoadExternalLibrary(name, out assembly))
+                {
+                    return assembly;
+                }
+
                 return null;
             }
 
@@ -98,7 +115,7 @@ public class PluginManager : IPluginManager
                 }
             }
         }
-        
+
         foreach (var plugin in _loadedPluginContexts)
         {
             try
@@ -112,6 +129,57 @@ public class PluginManager : IPluginManager
         }
     }
 
+    private bool TryLoadExternalLibrary(AssemblyName assemblyName, out Assembly? assembly)
+    {
+        assembly = null;
+        if (!TryResolveReflectionAssemblyPath(out var pluginName, out var pluginPath))
+        {
+            return false;
+        }
+
+        if (!TryLoadDependency(pluginPath, pluginName, assemblyName, out assembly))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool TryLoadDependency(string pluginAssemblyPath,
+        string pluginAssemblyName,
+        AssemblyName dependencyAssemblyName,
+        out Assembly? assembly)
+    {
+        assembly = null;
+
+        var dependencyName = dependencyAssemblyName.Name!;
+        if (string.IsNullOrEmpty(pluginAssemblyPath) || _sharedAssemblies.ContainsKey(dependencyName))
+        {
+            return false;
+        }
+
+        var resolver = new PluginContextNuGetDependencyResolver(
+            rootAssemblyName: pluginAssemblyName,
+            rootAssemblyPath: Path.GetDirectoryName(pluginAssemblyPath)!,
+            assemblyName: dependencyAssemblyName);
+
+        var dependencyPath = resolver.ResolvePath();
+        if (string.IsNullOrWhiteSpace(dependencyPath))
+        {
+            return false;
+        }
+
+        var loader = PluginLoader.CreateFromAssemblyFile(dependencyPath, configure: c =>
+        {
+            c.PreferSharedTypes = true;
+        });
+
+        assembly = loader.LoadDefaultAssembly();
+        _sharedAssemblies[dependencyAssemblyName.Name!] = assembly;
+
+        return true;
+    }
+
     public IEnumerable<PluginContext> GetLoadedPlugins()
     {
         return _loadedPluginContexts;
@@ -123,5 +191,28 @@ public class PluginManager : IPluginManager
             _loadedPluginContexts.Select(x => x.PluginId).DefaultIfEmpty(0).Max() + 1);
         _loadedPluginContexts.Add(plugin);
         plugin.Load();
+    }
+
+    private static bool TryResolveReflectionAssemblyPath(out string? assemblyName, out string? assemblyPath)
+    {
+        assemblyPath = null;
+        assemblyName = null;
+
+        if (AssemblyLoadContext.CurrentContextualReflectionContext is var reflectionContext && reflectionContext is null)
+        {
+            return false;
+        }
+
+        var mainAssemblyPathField = reflectionContext
+            .GetType()
+            .GetField("_mainAssemblyPath", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        if (mainAssemblyPathField is null)
+        {
+            return false;
+        }
+
+        assemblyPath = (string) mainAssemblyPathField.GetValue(reflectionContext)!;
+        return !string.IsNullOrEmpty(assemblyPath);
     }
 }


### PR DESCRIPTION
Hello, let me introduce an **expiremental plugin dependency resolver** to improve how external dependencies are resolved when loading plugins.

## Problem

By default, `McMaster.NETCore.Plugins` does not handle scenarios where NuGet packages need to be loaded from a shared/global location. To address this, I implemented a custom resolver that can locate dependencies in the NuGet packages root folder (either from the `NUGET_PACKAGES` environment variable or the default `.nuget/packages` location).

## Motivation

Previously, for every plugin that depended on a NuGet package, you had to manually place the assemblies into the `shared` folder. These changes remove that friction by enabling automatic resolution.

## Configuration

Since this feature is experimental, it is disabled by default.
To enable it, set the following in `core.json`:

```json
"UseExperimentalPluginDependencyResolver": true
```
