### PR TITLE
feat: Implement bypass hook for Invoke method

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/API.cs
+++ b/managed/CounterStrikeSharp.API/Core/API.cs
@@ -1421,10 +1421,11 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
-        public static T ExecuteVirtualFunction<T>(IntPtr function, object[] arguments){
+        public static T ExecuteVirtualFunction<T>(IntPtr function, bool bypass, object[] arguments){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(function);
+			ScriptContext.GlobalScriptContext.Push(bypass);
 			foreach (var obj in arguments)
 			{
 				ScriptContext.GlobalScriptContext.Push(obj);

--- a/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/BaseMemoryFunction.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/BaseMemoryFunction.cs
@@ -67,13 +67,13 @@ public abstract class BaseMemoryFunction : NativeObject
         NativeAPI.UnhookFunction(Handle, handler, mode == HookMode.Post);
     }
 
-    protected T InvokeInternal<T>(params object[] args)
+    protected T InvokeInternal<T>(bool bypass, params object[] args)
     {
-        return NativeAPI.ExecuteVirtualFunction<T>(Handle, args);
+        return NativeAPI.ExecuteVirtualFunction<T>(Handle, bypass, args);
     }
 
-    protected void InvokeInternalVoid(params object[] args)
+    protected void InvokeInternalVoid(bool bypass, params object[] args)
     {
-        NativeAPI.ExecuteVirtualFunction<object>(Handle, args);
+        NativeAPI.ExecuteVirtualFunction<object>(Handle, bypass, args);
     }
 }

--- a/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/MemoryFunctionVoid.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/MemoryFunctionVoid.cs
@@ -15,9 +15,9 @@ public class MemoryFunctionVoid : BaseMemoryFunction
     {
     }
 
-    public void Invoke()
+    public void Invoke(bool bypasshook = false)
     {
-        InvokeInternalVoid();
+        InvokeInternalVoid(bypasshook);
     }
 }
 
@@ -33,9 +33,9 @@ public class MemoryFunctionVoid<T1> : BaseMemoryFunction
     {
     }
 
-    public void Invoke(T1 arg1)
+    public void Invoke(T1 arg1, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1);
+        InvokeInternalVoid(bypasshook, arg1);
     }
 }
 
@@ -51,9 +51,9 @@ public class MemoryFunctionVoid<T1, T2> : BaseMemoryFunction
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2)
+    public void Invoke(T1 arg1, T2 arg2, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2);
+        InvokeInternalVoid(bypasshook, arg1, arg2);
     }
 }
 
@@ -69,9 +69,9 @@ public class MemoryFunctionVoid<T1, T2, T3> : BaseMemoryFunction
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3);
     }
 }
 
@@ -95,9 +95,9 @@ public class MemoryFunctionVoid<T1, T2, T3, T4> : BaseMemoryFunction
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3, arg4);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3, arg4);
     }
 }
 
@@ -123,9 +123,9 @@ public class MemoryFunctionVoid<T1, T2, T3, T4, T5> : BaseMemoryFunction
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3, arg4, arg5);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3, arg4, arg5);
     }
 }
 
@@ -151,9 +151,9 @@ public class MemoryFunctionVoid<T1, T2, T3, T4, T5, T6> : BaseMemoryFunction
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3, arg4, arg5, arg6);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 }
 
@@ -181,9 +181,9 @@ public class MemoryFunctionVoid<T1, T2, T3, T4, T5, T6, T7> : BaseMemoryFunction
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 }
 
@@ -211,9 +211,9 @@ public class MemoryFunctionVoid<T1, T2, T3, T4, T5, T6, T7, T8> : BaseMemoryFunc
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 }
 
@@ -243,9 +243,9 @@ public class MemoryFunctionVoid<T1, T2, T3, T4, T5, T6, T7, T8, T9> : BaseMemory
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
     }
 }
 
@@ -275,9 +275,9 @@ public class MemoryFunctionVoid<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : BaseM
     {
     }
 
-    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+    public void Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, bool bypasshook = false)
     {
-        InvokeInternalVoid(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+        InvokeInternalVoid(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
     }
 }
 

--- a/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/MemoryFunctionWithReturn.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/DynamicFunctions/MemoryFunctionWithReturn.cs
@@ -17,9 +17,9 @@ public class MemoryFunctionWithReturn<TResult> : BaseMemoryFunction
     {
     }
 
-    public TResult Invoke()
+    public TResult Invoke(bool bypasshook)
     {
-        return InvokeInternal<TResult>();
+        return InvokeInternal<TResult>(bypasshook);
     }
 }
 
@@ -35,9 +35,9 @@ public class MemoryFunctionWithReturn<T1, TResult> : BaseMemoryFunction
     {
     }
 
-    public TResult Invoke(T1 arg1)
+    public TResult Invoke(T1 arg1, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1);
+        return InvokeInternal<TResult>(bypasshook, arg1);
     }
 }
 
@@ -53,9 +53,9 @@ public class MemoryFunctionWithReturn<T1, T2, TResult> : BaseMemoryFunction
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2)
+    public TResult Invoke(T1 arg1, T2 arg2, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2);
     }
 }
 
@@ -71,9 +71,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, TResult> : BaseMemoryFunction
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3);
     }
 }
 
@@ -97,9 +97,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, T4, TResult> : BaseMemoryFunct
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3, arg4);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3, arg4);
     }
 }
 
@@ -123,9 +123,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, T4, T5, TResult> : BaseMemoryF
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3, arg4, arg5);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3, arg4, arg5);
     }
 }
 
@@ -149,9 +149,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, T4, T5, T6, TResult> : BaseMem
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3, arg4, arg5, arg6);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 }
 
@@ -177,9 +177,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, T4, T5, T6, T7, TResult> : Bas
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 }
 
@@ -205,9 +205,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, T4, T5, T6, T7, T8, TResult> :
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 }
 
@@ -233,9 +233,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResul
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
     }
 }
 
@@ -263,9 +263,9 @@ public class MemoryFunctionWithReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T
     {
     }
 
-    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+    public TResult Invoke(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, bool bypasshook = false)
     {
-        return InvokeInternal<TResult>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+        return InvokeInternal<TResult>(bypasshook, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
     }
 }
 

--- a/managed/CounterStrikeSharp.API/Modules/Memory/VirtualFunctionOffset.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/VirtualFunctionOffset.cs
@@ -35,17 +35,17 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
         #region Void Actions
 
-        public static Action Create(IntPtr objectPtr, int offset)
+        public static Action Create(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = Enumerable.Empty<DataType>().ToArray();
 
             var virtualFunctionPointer = CreateVirtualFunction(objectPtr, offset, arguments,
                 DataType.DATA_TYPE_VOID, arguments.Cast<object>().ToArray());
 
-            return () => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { }); };
+            return () => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { }); };
         }
 
-        public static Action<TArg1> CreateVoid<TArg1>(IntPtr objectPtr, int offset)
+        public static Action<TArg1> CreateVoid<TArg1>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -62,11 +62,11 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1 });
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1 });
             };
         }
 
-        public static Action<TArg1, TArg2> CreateVoid<TArg1, TArg2>(IntPtr objectPtr, int offset)
+        public static Action<TArg1, TArg2> CreateVoid<TArg1, TArg2>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -84,11 +84,11 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1, arg2 });
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2 });
             };
         }
 
-        public static Action<TArg1, TArg2, TArg3> CreateVoid<TArg1, TArg2, TArg3>(IntPtr objectPtr, int offset)
+        public static Action<TArg1, TArg2, TArg3> CreateVoid<TArg1, TArg2, TArg3>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -107,12 +107,12 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1, arg2, arg3 });
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3 });
             };
         }
 
         public static Action<TArg1, TArg2, TArg3, TArg4> CreateVoid<TArg1, TArg2, TArg3, TArg4>(IntPtr objectPtr,
-            int offset)
+            int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -132,13 +132,13 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3, arg4) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4 });
             };
         }
 
         public static Action<TArg1, TArg2, TArg3, TArg4, TArg5> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5>(
-            IntPtr objectPtr, int offset)
+            IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -159,14 +159,14 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3, arg4, arg5) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5 });
             };
         }
 
         public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5,
             TArg6>(
-            IntPtr objectPtr, int offset)
+            IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -188,14 +188,14 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3, arg4, arg5, arg6) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
             };
         }
 
         public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7> CreateVoid<TArg1, TArg2, TArg3, TArg4,
             TArg5,
-            TArg6, TArg7>(IntPtr objectPtr, int offset)
+            TArg6, TArg7>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -218,14 +218,14 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
             };
         }
 
         public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8> CreateVoid<TArg1, TArg2, TArg3,
             TArg4,
-            TArg5, TArg6, TArg7, TArg8>(IntPtr objectPtr, int offset)
+            TArg5, TArg6, TArg7, TArg8>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -249,14 +249,14 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
             };
         }
 
         public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9> CreateVoid<TArg1, TArg2,
             TArg3,
-            TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(IntPtr objectPtr, int offset)
+            TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -281,14 +281,14 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
             };
         }
 
         public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10> CreateVoid<TArg1,
             TArg2,
-            TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10>(IntPtr objectPtr, int offset)
+            TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -314,7 +314,7 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
             {
-                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 });
             };
         }
@@ -323,7 +323,7 @@ namespace CounterStrikeSharp.API.Modules.Memory
 
         #region Func
 
-        public static Func<TResult> Create<TResult>(IntPtr objectPtr, int offset)
+        public static Func<TResult> Create<TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = Enumerable.Empty<DataType>().ToArray();
 
@@ -335,10 +335,10 @@ namespace CounterStrikeSharp.API.Modules.Memory
             var virtualFunctionPointer = CreateVirtualFunction(objectPtr, offset, arguments,
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-            return () => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { });
+            return () => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { });
         }
 
-        public static Func<TArg1, TResult> Create<TArg1, TResult>(IntPtr objectPtr, int offset)
+        public static Func<TArg1, TResult> Create<TArg1, TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -353,10 +353,10 @@ namespace CounterStrikeSharp.API.Modules.Memory
             var virtualFunctionPointer = CreateVirtualFunction(objectPtr, offset, arguments.Cast<DataType>(),
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-            return (arg1) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1 });
+            return (arg1) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1 });
         }
 
-        public static Func<TArg1, TArg2, TResult> Create<TArg1, TArg2, TResult>(IntPtr objectPtr, int offset)
+        public static Func<TArg1, TArg2, TResult> Create<TArg1, TArg2, TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -373,11 +373,11 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2 });
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TResult> Create<TArg1, TArg2, TArg3, TResult>(IntPtr objectPtr,
-            int offset)
+            int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -395,11 +395,11 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2, arg3 });
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TArg4, TResult> Create<TArg1, TArg2, TArg3, TArg4, TResult>(
-            IntPtr objectPtr, int offset)
+            IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -418,12 +418,12 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3, arg4) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TResult> Create<TArg1, TArg2, TArg3, TArg4, TArg5,
-            TResult>(IntPtr objectPtr, int offset)
+            TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -443,12 +443,12 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3, arg4, arg5) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TResult> Create<TArg1, TArg2, TArg3, TArg4, TArg5,
-            TArg6, TResult>(IntPtr objectPtr, int offset)
+            TArg6, TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -469,12 +469,12 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3, arg4, arg5, arg6) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TResult> Create<TArg1, TArg2, TArg3, TArg4,
-            TArg5, TArg6, TArg7, TResult>(IntPtr objectPtr, int offset)
+            TArg5, TArg6, TArg7, TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -496,12 +496,12 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TResult> Create<TArg1, TArg2, TArg3,
-            TArg4, TArg5, TArg6, TArg7, TArg8, TResult>(IntPtr objectPtr, int offset)
+            TArg4, TArg5, TArg6, TArg7, TArg8, TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -524,12 +524,12 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult> Create<TArg1, TArg2,
-            TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult>(IntPtr objectPtr, int offset)
+            TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -553,12 +553,12 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
         }
 
         public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult> Create<TArg1,
-            TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult>(IntPtr objectPtr, int offset)
+            TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult>(IntPtr objectPtr, int offset, bool bypasshook = false)
         {
             var arguments = new[]
             {
@@ -583,7 +583,7 @@ namespace CounterStrikeSharp.API.Modules.Memory
                 (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
             return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
-                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+                NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                     new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 });
         }
 

--- a/managed/CounterStrikeSharp.API/Modules/Memory/VirtualFunctionSignature.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/VirtualFunctionSignature.cs
@@ -68,7 +68,7 @@ public partial class VirtualFunction
     }
 
     #region Funcs
-    public static Func<TResult> Create<TResult>(string signature)
+    public static Func<TResult> Create<TResult>(string signature, bool bypasshook = false)
     {
         var arguments = Enumerable.Empty<DataType>().ToArray();
 
@@ -80,10 +80,10 @@ public partial class VirtualFunction
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, arguments,
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-        return () => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { });
+        return () => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { });
     }
 
-    public static Func<TArg1, TResult> Create<TArg1, TResult>(string signature)
+    public static Func<TArg1, TResult> Create<TArg1, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -98,10 +98,10 @@ public partial class VirtualFunction
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, arguments.Cast<DataType>(),
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-        return (arg1) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1 });
+        return (arg1) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1 });
     }
 
-    public static Func<TArg1, TArg2, TResult> Create<TArg1, TArg2, TResult>(string signature)
+    public static Func<TArg1, TArg2, TResult> Create<TArg1, TArg2, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -118,10 +118,10 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2 });
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2 });
     }
 
-    public static Func<TArg1, TArg2, TArg3, TResult> Create<TArg1, TArg2, TArg3, TResult>(string signature)
+    public static Func<TArg1, TArg2, TArg3, TResult> Create<TArg1, TArg2, TArg3, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -139,11 +139,11 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2, arg3 });
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TResult> Create<TArg1, TArg2, TArg3, TArg4, TResult>(
-        string signature)
+        string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -162,11 +162,11 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2, arg3, arg4 });
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3, arg4 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TResult> Create<TArg1, TArg2, TArg3, TArg4, TArg5, TResult>(
-        string signature)
+        string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -186,12 +186,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TResult> Create<TArg1, TArg2, TArg3, TArg4, TArg5,
-        TArg6, TResult>(string signature)
+        TArg6, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -211,12 +211,12 @@ public partial class VirtualFunction
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, arguments.Cast<DataType>(),
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-        return (arg1, arg2, arg3, arg4, arg5, arg6) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+        return (arg1, arg2, arg3, arg4, arg5, arg6) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
             new object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TResult> Create<TArg1, TArg2, TArg3, TArg4,
-        TArg5, TArg6, TArg7, TResult>(string signature)
+        TArg5, TArg6, TArg7, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -238,12 +238,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TResult> Create<TArg1, TArg2, TArg3,
-        TArg4, TArg5, TArg6, TArg7, TArg8, TResult>(string signature)
+        TArg4, TArg5, TArg6, TArg7, TArg8, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -266,12 +266,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult> Create<TArg1, TArg2,
-        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult>(string signature)
+        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -295,12 +295,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult> Create<TArg1,
-        TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult>(string signature)
+        TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -325,14 +325,14 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 });
     }
 
     #endregion
 
     #region FuncsBinary
-    public static Func<TResult> Create<TResult>(string signature, string binarypath)
+    public static Func<TResult> Create<TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = Enumerable.Empty<DataType>().ToArray();
 
@@ -341,13 +341,13 @@ public partial class VirtualFunction
             throw new Exception($"Invalid argument type(s) supplied to Virtual Function");
         }
 
-        var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, binarypath,  arguments,
+        var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, binarypath, arguments,
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-        return () => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { });
+        return () => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { });
     }
 
-    public static Func<TArg1, TResult> Create<TArg1, TResult>(string signature, string binarypath)
+    public static Func<TArg1, TResult> Create<TArg1, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -362,10 +362,10 @@ public partial class VirtualFunction
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, binarypath, arguments.Cast<DataType>(),
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-        return (arg1) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1 });
+        return (arg1) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1 });
     }
 
-    public static Func<TArg1, TArg2, TResult> Create<TArg1, TArg2, TResult>(string signature, string binarypath)
+    public static Func<TArg1, TArg2, TResult> Create<TArg1, TArg2, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -382,10 +382,10 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2 });
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2 });
     }
 
-    public static Func<TArg1, TArg2, TArg3, TResult> Create<TArg1, TArg2, TArg3, TResult>(string signature, string binarypath)
+    public static Func<TArg1, TArg2, TArg3, TResult> Create<TArg1, TArg2, TArg3, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -403,11 +403,11 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2, arg3 });
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TResult> Create<TArg1, TArg2, TArg3, TArg4, TResult>(
-        string signature, string binarypath)
+        string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -426,11 +426,11 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, new object[] { arg1, arg2, arg3, arg4 });
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3, arg4 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TResult> Create<TArg1, TArg2, TArg3, TArg4, TArg5, TResult>(
-        string signature, string binarypath)
+        string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -450,12 +450,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TResult> Create<TArg1, TArg2, TArg3, TArg4, TArg5,
-        TArg6, TResult>(string signature, string binarypath)
+        TArg6, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -475,12 +475,12 @@ public partial class VirtualFunction
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, binarypath, arguments.Cast<DataType>(),
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
-        return (arg1, arg2, arg3, arg4, arg5, arg6) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+        return (arg1, arg2, arg3, arg4, arg5, arg6) => NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
             new object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TResult> Create<TArg1, TArg2, TArg3, TArg4,
-        TArg5, TArg6, TArg7, TResult>(string signature, string binarypath)
+        TArg5, TArg6, TArg7, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -502,12 +502,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TResult> Create<TArg1, TArg2, TArg3,
-        TArg4, TArg5, TArg6, TArg7, TArg8, TResult>(string signature, string binarypath)
+        TArg4, TArg5, TArg6, TArg7, TArg8, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -530,12 +530,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult> Create<TArg1, TArg2,
-        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult>(string signature, string binarypath)
+        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -559,12 +559,12 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
     }
 
     public static Func<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult> Create<TArg1,
-        TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult>(string signature, string binarypath)
+        TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10, TResult>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -589,24 +589,24 @@ public partial class VirtualFunction
             (DataType)typeof(TResult).ToDataType()!, arguments.Cast<object>().ToArray());
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
-            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<TResult>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 });
     }
     #endregion
 
     #region Void Actions
 
-    public static Action CreateVoid(string signature)
+    public static Action CreateVoid(string signature, bool bypasshook = false)
     {
         var arguments = Enumerable.Empty<DataType>().ToArray();
 
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, arguments,
             DataType.DATA_TYPE_VOID, arguments.Cast<object>().ToArray());
 
-        return () => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { }); };
+        return () => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { }); };
     }
 
-    public static Action<TArg1> CreateVoid<TArg1>(string signature)
+    public static Action<TArg1> CreateVoid<TArg1>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -621,10 +621,10 @@ public partial class VirtualFunction
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, arguments.Cast<DataType>(),
             DataType.DATA_TYPE_VOID, arguments.Cast<object>().ToArray());
 
-        return (arg1) => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1 }); };
+        return (arg1) => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1 }); };
     }
 
-    public static Action<TArg1, TArg2> CreateVoid<TArg1, TArg2>(string signature)
+    public static Action<TArg1, TArg2> CreateVoid<TArg1, TArg2>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -642,11 +642,11 @@ public partial class VirtualFunction
 
         return (arg1, arg2) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1, arg2 });
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2 });
         };
     }
 
-    public static Action<TArg1, TArg2, TArg3> CreateVoid<TArg1, TArg2, TArg3>(string signature)
+    public static Action<TArg1, TArg2, TArg3> CreateVoid<TArg1, TArg2, TArg3>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -665,11 +665,11 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1, arg2, arg3 });
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3 });
         };
     }
 
-    public static Action<TArg1, TArg2, TArg3, TArg4> CreateVoid<TArg1, TArg2, TArg3, TArg4>(string signature)
+    public static Action<TArg1, TArg2, TArg3, TArg4> CreateVoid<TArg1, TArg2, TArg3, TArg4>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -689,13 +689,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5>(
-        string signature)
+        string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -716,13 +716,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(
-        string signature)
+        string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -744,13 +744,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5,
-        TArg6, TArg7>(string signature)
+        TArg6, TArg7>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -773,13 +773,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8> CreateVoid<TArg1, TArg2, TArg3, TArg4,
-        TArg5, TArg6, TArg7, TArg8>(string signature)
+        TArg5, TArg6, TArg7, TArg8>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -803,13 +803,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9> CreateVoid<TArg1, TArg2, TArg3,
-        TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(string signature)
+        TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -834,13 +834,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10> CreateVoid<TArg1, TArg2,
-        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10>(string signature)
+        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10>(string signature, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -866,7 +866,7 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 });
         };
     }
@@ -874,17 +874,17 @@ public partial class VirtualFunction
     #endregion
 
     #region Void Actions Binary
-    public static Action CreateVoid(string signature, string binarypath)
+    public static Action CreateVoid(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = Enumerable.Empty<DataType>().ToArray();
 
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, binarypath, arguments,
             DataType.DATA_TYPE_VOID, arguments.Cast<object>().ToArray());
 
-        return () => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { }); };
+        return () => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { }); };
     }
 
-    public static Action<TArg1> CreateVoid<TArg1>(string signature, string binarypath)
+    public static Action<TArg1> CreateVoid<TArg1>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -899,10 +899,10 @@ public partial class VirtualFunction
         var virtualFunctionPointer = CreateVirtualFunctionBySignature(signature, binarypath, arguments.Cast<DataType>(),
             DataType.DATA_TYPE_VOID, arguments.Cast<object>().ToArray());
 
-        return (arg1) => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1 }); };
+        return (arg1) => { NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1 }); };
     }
 
-    public static Action<TArg1, TArg2> CreateVoid<TArg1, TArg2>(string signature, string binarypath)
+    public static Action<TArg1, TArg2> CreateVoid<TArg1, TArg2>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -920,11 +920,11 @@ public partial class VirtualFunction
 
         return (arg1, arg2) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1, arg2 });
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2 });
         };
     }
 
-    public static Action<TArg1, TArg2, TArg3> CreateVoid<TArg1, TArg2, TArg3>(string signature, string binarypath)
+    public static Action<TArg1, TArg2, TArg3> CreateVoid<TArg1, TArg2, TArg3>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -943,11 +943,11 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, new object[] { arg1, arg2, arg3 });
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook, new object[] { arg1, arg2, arg3 });
         };
     }
 
-    public static Action<TArg1, TArg2, TArg3, TArg4> CreateVoid<TArg1, TArg2, TArg3, TArg4>(string signature, string binarypath)
+    public static Action<TArg1, TArg2, TArg3, TArg4> CreateVoid<TArg1, TArg2, TArg3, TArg4>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -967,13 +967,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5>(
-        string signature, string binarypath)
+        string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -994,13 +994,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(
-        string signature, string binarypath)
+        string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -1022,13 +1022,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7> CreateVoid<TArg1, TArg2, TArg3, TArg4, TArg5,
-        TArg6, TArg7>(string signature, string binarypath)
+        TArg6, TArg7>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -1051,13 +1051,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8> CreateVoid<TArg1, TArg2, TArg3, TArg4,
-        TArg5, TArg6, TArg7, TArg8>(string signature, string binarypath)
+        TArg5, TArg6, TArg7, TArg8>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -1081,13 +1081,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9> CreateVoid<TArg1, TArg2, TArg3,
-        TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(string signature, string binarypath)
+        TArg4, TArg5, TArg6, TArg7, TArg8, TArg9>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -1112,13 +1112,13 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 });
         };
     }
 
     public static Action<TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10> CreateVoid<TArg1, TArg2,
-        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10>(string signature, string binarypath)
+        TArg3, TArg4, TArg5, TArg6, TArg7, TArg8, TArg9, TArg10>(string signature, string binarypath, bool bypasshook = false)
     {
         var arguments = new[]
         {
@@ -1144,7 +1144,7 @@ public partial class VirtualFunction
 
         return (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) =>
         {
-            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer,
+            NativeAPI.ExecuteVirtualFunction<object>(virtualFunctionPointer, bypasshook,
                 new object[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 });
         };
     }

--- a/managed/CounterStrikeSharp.API/Modules/Memory/VirtualFunctions.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/VirtualFunctions.cs
@@ -14,51 +14,58 @@ public static class VirtualFunctions
         new(GameData.GetSignature("ClientPrint"));
 
     public static Action<IntPtr, HudDestination, string, IntPtr, IntPtr, IntPtr, IntPtr> ClientPrint =
-        ClientPrintFunc.Invoke;
+        (arg1, arg2, arg3, arg4, arg5, arg6, arg7) => ClientPrintFunc.Invoke(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 
     public static MemoryFunctionVoid<HudDestination, string, IntPtr, IntPtr, IntPtr, IntPtr> ClientPrintAllFunc =
         new(GameData.GetSignature("UTIL_ClientPrintAll"));
 
     public static Action<HudDestination, string, IntPtr, IntPtr, IntPtr, IntPtr> ClientPrintAll =
-        ClientPrintAllFunc.Invoke;
+        (arg1, arg2, arg3, arg4, arg5, arg6) => ClientPrintAllFunc.Invoke(arg1, arg2, arg3, arg4, arg5, arg6);
 
     // void (*FnGiveNamedItem)(void* itemService,const char* pchName, void* iSubType,void* pScriptItem, void* a5,void* a6) = nullptr;
     public static MemoryFunctionWithReturn<IntPtr, string, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr> GiveNamedItemFunc =
         new(GameData.GetSignature("GiveNamedItem"));
 
-    public static Func<IntPtr, string, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr> GiveNamedItem = GiveNamedItemFunc.Invoke;
+    public static Func<IntPtr, string, IntPtr, IntPtr, IntPtr, IntPtr, IntPtr> GiveNamedItem =
+        (arg1, arg2, arg3, arg4, arg5, arg6) => GiveNamedItemFunc.Invoke(arg1, arg2, arg3, arg4, arg5, arg6);
 
     public static MemoryFunctionVoid<IntPtr, byte> SwitchTeamFunc =
         new(GameData.GetSignature("CCSPlayerController_SwitchTeam"));
 
-    public static Action<IntPtr, byte> SwitchTeam = SwitchTeamFunc.Invoke;
+    public static Action<IntPtr, byte> SwitchTeam =
+        (arg1, arg2) => SwitchTeam.Invoke(arg1, arg2);
 
     // void(*UTIL_Remove)(CEntityInstance*);
     public static MemoryFunctionVoid<IntPtr> UTIL_RemoveFunc =
         new(GameData.GetSignature("UTIL_Remove"));
 
-    public static Action<IntPtr> UTIL_Remove = UTIL_RemoveFunc.Invoke;
+    public static Action<IntPtr> UTIL_Remove =
+        (arg1) => UTIL_RemoveFunc.Invoke(arg1);
 
     // void(*CBaseModelEntity_SetModel)(CBaseModelEntity*, const char*);
     public static MemoryFunctionVoid<IntPtr, string> SetModelFunc =
         new(GameData.GetSignature("CBaseModelEntity_SetModel"));
 
-    public static Action<IntPtr, string> SetModel = SetModelFunc.Invoke;
+    public static Action<IntPtr, string> SetModel =
+        (arg1, arg2) => SetModelFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionVoid<nint, RoundEndReason, float, nint, byte> TerminateRoundFunc =
         new(GameData.GetSignature("CCSGameRules_TerminateRound"));
 
-    public static Action<IntPtr, RoundEndReason, float, nint, byte> TerminateRound = TerminateRoundFunc.Invoke;
+    public static Action<IntPtr, RoundEndReason, float, nint, byte> TerminateRound =
+        (arg1, arg2, arg3, arg4, arg5) => TerminateRoundFunc.Invoke(arg1, arg2, arg3, arg4, arg5);
 
     public static MemoryFunctionWithReturn<string, int, IntPtr> UTIL_CreateEntityByNameFunc =
         new(GameData.GetSignature("UTIL_CreateEntityByName"));
 
-    public static Func<string, int, IntPtr> UTIL_CreateEntityByName = UTIL_CreateEntityByNameFunc.Invoke;
+    public static Func<string, int, IntPtr> UTIL_CreateEntityByName =
+        (arg1, arg2) => UTIL_CreateEntityByNameFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionVoid<IntPtr, IntPtr> CBaseEntity_DispatchSpawnFunc =
         new(GameData.GetSignature("CBaseEntity_DispatchSpawn"));
 
-    public static Action<IntPtr, IntPtr> CBaseEntity_DispatchSpawn = CBaseEntity_DispatchSpawnFunc.Invoke;
+    public static Action<IntPtr, IntPtr> CBaseEntity_DispatchSpawn =
+        (arg1, arg2) => CBaseEntity_DispatchSpawnFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionVoid<CBasePlayerController, CBasePlayerPawn, bool, bool> CBasePlayerController_SetPawnFunc =
         new(GameData.GetSignature("CBasePlayerController_SetPawn"));
@@ -66,42 +73,48 @@ public static class VirtualFunctions
     public static MemoryFunctionVoid<CEntityInstance, CTakeDamageInfo> CBaseEntity_TakeDamageOldFunc =
         new(GameData.GetSignature("CBaseEntity_TakeDamageOld"));
 
-    public static Action<CEntityInstance, CTakeDamageInfo> CBaseEntity_TakeDamageOld = CBaseEntity_TakeDamageOldFunc.Invoke;
+    public static Action<CEntityInstance, CTakeDamageInfo> CBaseEntity_TakeDamageOld =
+        (arg1, arg2) => CBaseEntity_TakeDamageOldFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionWithReturn<CCSPlayer_WeaponServices, CBasePlayerWeapon, bool> CCSPlayer_WeaponServices_CanUseFunc =
         new(GameData.GetSignature("CCSPlayer_WeaponServices_CanUse"));
 
     public static Func<CCSPlayer_WeaponServices, CBasePlayerWeapon, bool> CCSPlayer_WeaponServices_CanUse =
-        CCSPlayer_WeaponServices_CanUseFunc.Invoke;
+        (arg1, arg2) => CCSPlayer_WeaponServices_CanUseFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionWithReturn<int, string, CCSWeaponBaseVData> GetCSWeaponDataFromKeyFunc =
         new(GameData.GetSignature("GetCSWeaponDataFromKey"));
 
-    public static Func<int, string, CCSWeaponBaseVData> GetCSWeaponDataFromKey = GetCSWeaponDataFromKeyFunc.Invoke;
+    public static Func<int, string, CCSWeaponBaseVData> GetCSWeaponDataFromKey =
+        (arg1, arg2) => GetCSWeaponDataFromKeyFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionWithReturn<CCSPlayer_ItemServices, CEconItemView, AcquireMethod, IntPtr, AcquireResult>
         CCSPlayer_ItemServices_CanAcquireFunc = new(GameData.GetSignature("CCSPlayer_ItemServices_CanAcquire"));
 
     public static Func<CCSPlayer_ItemServices, CEconItemView, AcquireMethod, IntPtr, AcquireResult> CCSPlayer_ItemServices_CanAcquire =
-        CCSPlayer_ItemServices_CanAcquireFunc.Invoke;
+        (arg1, arg2, arg3, arg4) => CCSPlayer_ItemServices_CanAcquireFunc.Invoke(arg1, arg2, arg3, arg4);
 
     public static MemoryFunctionVoid<CCSPlayerPawnBase> CCSPlayerPawnBase_PostThinkFunc =
         new(GameData.GetSignature("CCSPlayerPawnBase_PostThink"));
 
-    public static Action<CCSPlayerPawnBase> CCSPlayerPawnBase_PostThink = CCSPlayerPawnBase_PostThinkFunc.Invoke;
+    public static Action<CCSPlayerPawnBase> CCSPlayerPawnBase_PostThink =
+        (arg1) => CCSPlayerPawnBase_PostThinkFunc.Invoke(arg1);
 
     public static MemoryFunctionVoid<CBaseTrigger, CBaseEntity> CBaseTrigger_StartTouchFunc =
         new(GameData.GetSignature("CBaseTrigger_StartTouch"));
 
-    public static Action<CBaseTrigger, CBaseEntity> CBaseTrigger_StartTouch = CBaseTrigger_StartTouchFunc.Invoke;
+    public static Action<CBaseTrigger, CBaseEntity> CBaseTrigger_StartTouch =
+        (arg1, arg2) => CBaseTrigger_StartTouchFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionVoid<CBaseTrigger, CBaseEntity> CBaseTrigger_EndTouchFunc =
         new(GameData.GetSignature("CBaseTrigger_EndTouch"));
 
-    public static Action<CBaseTrigger, CBaseEntity> CBaseTrigger_EndTouch = CBaseTrigger_EndTouchFunc.Invoke;
+    public static Action<CBaseTrigger, CBaseEntity> CBaseTrigger_EndTouch =
+        (arg1, arg2) => CBaseTrigger_EndTouchFunc.Invoke(arg1, arg2);
 
     public static MemoryFunctionVoid<IntPtr, IntPtr> RemovePlayerItemFunc =
         new(GameData.GetSignature("CBasePlayerPawn_RemovePlayerItem"));
 
-    public static Action<IntPtr, IntPtr> RemovePlayerItemVirtual = RemovePlayerItemFunc.Invoke;
+    public static Action<IntPtr, IntPtr> RemovePlayerItemVirtual =
+        (arg1, arg2) => RemovePlayerItemFunc.Invoke(arg1, arg2);
 }

--- a/src/core/function.h
+++ b/src/core/function.h
@@ -93,11 +93,12 @@ class ValveFunction
     void SetOffset(int offset) { m_offset = offset; }
     void SetSignature(const char* signature) { m_signature = signature; }
 
-    void Call(ScriptContext& args, int offset = 0);
+    void Call(ScriptContext& args, int offset = 0, bool bypass = false);
     void AddHook(CallbackT callable, bool post);
     void RemoveHook(CallbackT callable, bool post);
 
     void* m_ulAddr;
+    void* m_trampoline;
     std::vector<DataType_t> m_Args;
     DataType_t m_eReturnType;
 

--- a/src/scripting/natives/natives_memory.cpp
+++ b/src/scripting/natives/natives_memory.cpp
@@ -127,6 +127,7 @@ void UnhookFunction(ScriptContext& script_context)
 void ExecuteVirtualFunction(ScriptContext& script_context)
 {
     auto function = script_context.GetArgument<ValveFunction*>(0);
+    auto bypasshook = script_context.GetArgument<bool>(1);
 
     if (!function)
     {
@@ -134,7 +135,7 @@ void ExecuteVirtualFunction(ScriptContext& script_context)
         return;
     }
 
-    function->Call(script_context, 1);
+    function->Call(script_context, 2, bypasshook);
 }
 
 int GetNetworkVectorSize(ScriptContext& script_context)

--- a/src/scripting/natives/natives_memory.yaml
+++ b/src/scripting/natives/natives_memory.yaml
@@ -2,7 +2,7 @@ CREATE_VIRTUAL_FUNCTION: pointer:pointer,vtableOffset:int,numArguments:int,retur
 CREATE_VIRTUAL_FUNCTION_BY_SIGNATURE: pointer:pointer,binaryName:string,signature:string,numArguments:int,returnType:int,arguments:object[] -> pointer
 HOOK_FUNCTION: function:pointer, hook:callback, post:bool -> void
 UNHOOK_FUNCTION: function:pointer, hook:callback, post:bool -> void
-EXECUTE_VIRTUAL_FUNCTION: function:pointer,arguments:object[] -> any
+EXECUTE_VIRTUAL_FUNCTION: function:pointer, bypass:bool, arguments:object[] -> any
 FIND_SIGNATURE: modulePath:string, signature:string -> pointer
 GET_NETWORK_VECTOR_SIZE: vec:pointer -> int
 GET_NETWORK_VECTOR_ELEMENT_AT: vec:pointer, index:int -> pointer


### PR DESCRIPTION
Assume we have:
```csharp
private MemoryFunctionVoid<nint, uint> func = new("48 8B C4 53 55 57 48 81 EC ? ? ? ? 0F B6 A9");
```

We created a hook for this function:
```csharp
func.Hook((h) => {
    // (possibly modify parameters)
    return HookResult.Changed;
}, HookMode.Pre);
```

However, at some point, we may need to invoke `func` without any modifications to its parameters **(i.e., bypassing the hook)**:
```csharp
func.Invoke(a, b);
```

This type of requirement is common, but previously, it could not be achieved using the CSS framework itself.  
Without a bypass mechanism, the above `Invoke` call would **still be intercepted by the hook**, potentially modifying the parameters, which contradicts the requirement

We have now implemented a **bypass hook** feature. By simply passing a `bool` parameter, you can easily bypass the hook:
```csharp
func.Invoke(a, b, true);
```

btw: This update is fully **backward compatible** (the default value of `bool bypass` is set to `false`). Even plugins built with older versions of CSS using `Hook`/`Invoke` will continue to work without issues
