### PR TITLE
feat: Implement `TerminateSelf(string reason)` to allow plugins to safely terminate themselves

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Application.cs
+++ b/managed/CounterStrikeSharp.API/Core/Application.cs
@@ -122,122 +122,128 @@ namespace CounterStrikeSharp.API.Core
             switch (info.GetArg(1))
             {
                 case "list":
-                {
-                    info.ReplyToCommand(
-                        $"  List of all plugins currently loaded by CounterStrikeSharp: {_pluginManager.GetLoadedPlugins().Count()} plugins loaded.");
-
-                    foreach (var plugin in _pluginManager.GetLoadedPlugins())
-                    {
-                        var sb = new StringBuilder();
-                        sb.AppendFormat("  [#{0}:{1}]: \"{2}\" ({3})", plugin.PluginId,
-                            plugin.State.ToString().ToUpper(), plugin.Plugin?.ModuleName ?? "Unknown",
-                            plugin.Plugin?.ModuleVersion ?? "Unknown");
-                        if (!string.IsNullOrEmpty(plugin.Plugin?.ModuleAuthor))
-                            sb.AppendFormat(" by {0}", plugin.Plugin.ModuleAuthor);
-                        if (!string.IsNullOrEmpty(plugin.Plugin?.ModuleDescription))
-                        {
-                            sb.Append("\n");
-                            sb.Append("    ");
-                            sb.Append(plugin.Plugin.ModuleDescription);
-                        }
-
-                        info.ReplyToCommand(sb.ToString());
-                    }
-
-                    break;
-                }
-                case "start":
-                case "load":
-                {
-                    if (info.ArgCount < 3)
                     {
                         info.ReplyToCommand(
-                            "Valid usage: css_plugins start/load [relative plugin path || absolute plugin path] (e.g \"TestPlugin\", \"plugins/TestPlugin/TestPlugin.dll\")\n");
+                            $"  List of all plugins currently loaded by CounterStrikeSharp: {_pluginManager.GetLoadedPlugins().Count()} plugins loaded.");
+
+                        foreach (var plugin in _pluginManager.GetLoadedPlugins())
+                        {
+                            var sb = new StringBuilder();
+                            sb.AppendFormat("  [#{0}:{1}]: \"{2}\" ({3})", plugin.PluginId,
+                                plugin.State.ToString().ToUpper(), plugin.Plugin?.ModuleName ?? "Unknown",
+                                plugin.Plugin?.ModuleVersion ?? "Unknown");
+                            if (!string.IsNullOrEmpty(plugin.Plugin?.ModuleAuthor))
+                                sb.AppendFormat(" by {0}", plugin.Plugin.ModuleAuthor);
+                            if (!string.IsNullOrEmpty(plugin.Plugin?.ModuleDescription))
+                            {
+                                sb.Append("\n");
+                                sb.Append("    ");
+                                sb.Append(plugin.Plugin.ModuleDescription);
+                            }
+
+                            if (plugin.State == PluginState.Unloaded && !string.IsNullOrEmpty(plugin.TerminationReason))
+                            {
+                                sb.Append("\n");
+                                sb.AppendFormat("    Termination Reason: {0}", plugin.TerminationReason);
+                            }
+
+                            info.ReplyToCommand(sb.ToString());
+                        }
+
                         break;
                     }
-
-                    // If our argument doesn't end in ".dll" - try and construct a path similar to PluginName/PluginName.dll.
-                    // We'll assume we have a full path if we have ".dll".
-                    var path = info.GetArg(2);
-                    path = Path.Combine(_scriptHostConfiguration.RootPath, !path.EndsWith(".dll") ? $"plugins/{path}/{path}.dll" : path);
-
-                    var plugin = _pluginContextQueryHandler.FindPluginByModulePath(path);
-
-                    if (plugin == null)
+                case "start":
+                case "load":
                     {
-                        try
+                        if (info.ArgCount < 3)
                         {
-                            _pluginManager.LoadPlugin(path);
-                            plugin = _pluginContextQueryHandler.FindPluginByModulePath(path);
+                            info.ReplyToCommand(
+                                "Valid usage: css_plugins start/load [relative plugin path || absolute plugin path] (e.g \"TestPlugin\", \"plugins/TestPlugin/TestPlugin.dll\")\n");
+                            break;
+                        }
+
+                        // If our argument doesn't end in ".dll" - try and construct a path similar to PluginName/PluginName.dll.
+                        // We'll assume we have a full path if we have ".dll".
+                        var path = info.GetArg(2);
+                        path = Path.Combine(_scriptHostConfiguration.RootPath, !path.EndsWith(".dll") ? $"plugins/{path}/{path}.dll" : path);
+
+                        var plugin = _pluginContextQueryHandler.FindPluginByModulePath(path);
+
+                        if (plugin == null)
+                        {
+                            try
+                            {
+                                _pluginManager.LoadPlugin(path);
+                                plugin = _pluginContextQueryHandler.FindPluginByModulePath(path);
+                                plugin.Plugin.OnAllPluginsLoaded(false);
+                            }
+                            catch (Exception e)
+                            {
+                                info.ReplyToCommand($"Could not load plugin \"{path}\"");
+                                Logger.LogError(e, "Could not load plugin \"{Path}\"", path);
+                            }
+                        }
+                        else
+                        {
+                            plugin.Load(false);
                             plugin.Plugin.OnAllPluginsLoaded(false);
                         }
-                        catch (Exception e)
-                        {
-                            info.ReplyToCommand($"Could not load plugin \"{path}\"");
-                            Logger.LogError(e, "Could not load plugin \"{Path}\"", path);
-                        }
-                    }
-                    else
-                    {
-                        plugin.Load(false);
-                        plugin.Plugin.OnAllPluginsLoaded(false);
-                    }
 
-                    break;
-                }
+                        break;
+                    }
 
                 case "stop":
                 case "unload":
-                {
-                    if (info.ArgCount < 3)
                     {
-                        info.ReplyToCommand(
-                            "Valid usage: css_plugins stop/unload [plugin name || #plugin id] (e.g \"TestPlugin\", \"1\")\n");
+                        if (info.ArgCount < 3)
+                        {
+                            info.ReplyToCommand(
+                                "Valid usage: css_plugins stop/unload [plugin name || #plugin id] (e.g \"TestPlugin\", \"1\")\n");
+                            break;
+                        }
+
+                        var pluginIdentifier = info.GetArg(2);
+                        string path;
+                        path = Path.Combine(_scriptHostConfiguration.RootPath,
+                            !pluginIdentifier.EndsWith(".dll") ? $"plugins/{pluginIdentifier}/{pluginIdentifier}.dll" : pluginIdentifier);
+
+                        var plugin = _pluginContextQueryHandler.FindPluginByIdOrName(pluginIdentifier)
+                                     ?? _pluginContextQueryHandler.FindPluginByModulePath(path);
+
+                        if (plugin == null)
+                        {
+                            info.ReplyToCommand($"Could not unload plugin \"{pluginIdentifier}\"");
+                            break;
+                        }
+
+                        plugin.Unload(false);
                         break;
                     }
-
-                    var pluginIdentifier = info.GetArg(2);
-                    string path;
-                    path = Path.Combine(_scriptHostConfiguration.RootPath,
-                        !pluginIdentifier.EndsWith(".dll") ? $"plugins/{pluginIdentifier}/{pluginIdentifier}.dll" : pluginIdentifier);
-
-                    var plugin = _pluginContextQueryHandler.FindPluginByIdOrName(pluginIdentifier)
-                                 ?? _pluginContextQueryHandler.FindPluginByModulePath(path);
-
-                    if (plugin == null)
-                    {
-                        info.ReplyToCommand($"Could not unload plugin \"{pluginIdentifier}\"");
-                        break;
-                    }
-
-                    plugin.Unload(false);
-                    break;
-                }
 
                 case "restart":
                 case "reload":
-                {
-                    if (info.ArgCount < 3)
                     {
-                        info.ReplyToCommand(
-                            "Valid usage: css_plugins restart/reload [plugin name || #plugin id] (e.g \"TestPlugin\", \"#1\")\n");
+                        if (info.ArgCount < 3)
+                        {
+                            info.ReplyToCommand(
+                                "Valid usage: css_plugins restart/reload [plugin name || #plugin id] (e.g \"TestPlugin\", \"#1\")\n");
+                            break;
+                        }
+
+                        var pluginIdentifier = info.GetArg(2);
+                        var plugin = _pluginContextQueryHandler.FindPluginByIdOrName(pluginIdentifier);
+
+                        if (plugin == null)
+                        {
+                            info.ReplyToCommand($"Could not reload plugin \"{pluginIdentifier}\"");
+                            break;
+                        }
+
+                        plugin.Unload(true);
+                        plugin.Load(true);
+                        plugin.Plugin.OnAllPluginsLoaded(true);
                         break;
                     }
-
-                    var pluginIdentifier = info.GetArg(2);
-                    var plugin = _pluginContextQueryHandler.FindPluginByIdOrName(pluginIdentifier);
-
-                    if (plugin == null)
-                    {
-                        info.ReplyToCommand($"Could not reload plugin \"{pluginIdentifier}\"");
-                        break;
-                    }
-
-                    plugin.Unload(true);
-                    plugin.Load(true);
-                    plugin.Plugin.OnAllPluginsLoaded(true);
-                    break;
-                }
 
                 default:
                     info.ReplyToCommand("Valid usage: css_plugins [option]\n" +


### PR DESCRIPTION
Prior to implementing `TerminateSelf`, plugins could only prevent initialization by throwing exceptions within their Load() override method. **Once fully loaded, however, plugins lacked any elegant mechanism for self-termination**

So, we implemented a state-aware TerminateSelf method:
- PluginState.Loading: Abort initialization by throwing an exception (handled by outer `try-catch`)
- PluginState.Loaded: Trigger the standard unload sequence for safe termination while preserving reload capability through css_plugins commands

<img width="1347" height="211" alt="image" src="https://github.com/user-attachments/assets/508c134c-822a-4c1e-92ea-b72f7e5aff33" />
<img width="737" height="214" alt="image" src="https://github.com/user-attachments/assets/76cbd548-ff11-4247-985b-e39439a7ca76" />

**btw.** Rather than injecting the complete `PluginContext` into `BasePlugin` (which would enable **dangerous control inversion** allowing plugins to manipulate framework internals or other plugin instances), we employed interface segregation by introducing `ISelfPluginControl`. This restricted interface exposes only self-termination capabilities to plugins, **100% adhering to the principle of least privilege** and preventing unauthorized access to framework components or cross-plugin manipulation 🤗