### PR TITLE
fix: do nothing when pressing 7 (prev) on the 1st page of a menu

### DIFF
--- a/managed/CounterStrikeSharp.API/Modules/Menu/BaseMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/BaseMenu.cs
@@ -108,9 +108,12 @@ public abstract class BaseMenuInstance : IMenuInstance
             return;
         }
 
-        if (key == 7 && HasPrevButton)
+        if (key == 7)
         {
-            PrevPage();
+            if (HasPrevButton)
+            {
+                PrevPage();
+            }
             return;
         }
 


### PR DESCRIPTION
This fixes a bug when pressing 7 on the first page (with no "Prev" button) calls the action for the first item on the second page (since this check doesn't bail out early).

Once this is merged, I have another change ready, a way to call a custom callback for the "Prev" button on the first page (to, for example, return to a previous menu).