### PR TITLE
feat: move next frame and next world update into managed side

### DIFF
--- a/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
@@ -807,32 +807,12 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
-        public static void QueueTaskForNextFrame(InputArgument callback){
-			lock (ScriptContext.GlobalScriptContext.Lock) {
-			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.SetIdentifier(0x9FE394D8);
-			ScriptContext.GlobalScriptContext.Invoke();
-			ScriptContext.GlobalScriptContext.CheckErrors();
-			}
-		}
-
         public static void QueueTaskForFrame(int tick, InputArgument callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(tick);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2F92C340);
-			ScriptContext.GlobalScriptContext.Invoke();
-			ScriptContext.GlobalScriptContext.CheckErrors();
-			}
-		}
-
-        public static void QueueTaskForNextWorldUpdate(InputArgument callback){
-			lock (ScriptContext.GlobalScriptContext.Lock) {
-			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.SetIdentifier(0xAD51A0C9);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
 			}

--- a/managed/CounterStrikeSharp.Tests.Native/NativeTestsPlugin.cs
+++ b/managed/CounterStrikeSharp.Tests.Native/NativeTestsPlugin.cs
@@ -38,7 +38,7 @@ namespace NativeTestsPlugin
 
         public override string ModuleDescription => "A an automated test plugin.";
 
-        private int gameThreadId;
+        public static int gameThreadId;
 
         public override void Load(bool hotReload)
         {

--- a/managed/CounterStrikeSharp.Tests.Native/TestUtils.cs
+++ b/managed/CounterStrikeSharp.Tests.Native/TestUtils.cs
@@ -5,7 +5,7 @@ public static class TestUtils
 {
     public static async Task WaitOneFrame()
     {
-        await Server.NextWorldUpdateAsync(() => { }).ConfigureAwait(false);
+        await Server.NextFrameAsync(() => { }).ConfigureAwait(false);
     }
 
     public static async Task WaitForSeconds(float seconds)

--- a/src/core/managers/server_manager.cpp
+++ b/src/core/managers/server_manager.cpp
@@ -20,7 +20,6 @@
 #include "scripting/callback_manager.h"
 
 #include "core/game_system.h"
-#include <concurrentqueue.h>
 
 SH_DECL_HOOK1_void(ISource2Server, ServerHibernationUpdate, SH_NOATTRIB, 0, bool);
 SH_DECL_HOOK0_void(ISource2Server, GameServerSteamAPIActivated, SH_NOATTRIB, 0);
@@ -174,20 +173,6 @@ void ServerManager::UpdateWhenNotInGame(float flFrameTime)
 
 void ServerManager::PreWorldUpdate(bool bSimulating)
 {
-    std::vector<std::function<void()>> out_list(1024);
-
-    auto size = m_nextWorldUpdateTasks.try_dequeue_bulk(out_list.begin(), 1024);
-
-    if (size > 0)
-    {
-        CSSHARP_CORE_TRACE("Executing queued tasks of size: {0} at time {1}", size, globals::getGlobalVars()->curtime);
-
-        for (size_t i = 0; i < size; i++)
-        {
-            out_list[i]();
-        }
-    }
-
     auto callback = globals::serverManager.on_server_pre_world_update;
 
     if (callback && callback->GetFunctionCount())
@@ -195,15 +180,6 @@ void ServerManager::PreWorldUpdate(bool bSimulating)
         callback->ScriptContext().Reset();
         callback->ScriptContext().Push(bSimulating);
         callback->Execute();
-    }
-}
-
-void ServerManager::AddTaskForNextWorldUpdate(std::function<void()>&& task)
-{
-    auto success = m_nextWorldUpdateTasks.enqueue(std::forward<decltype(task)>(task));
-    if (!success)
-    {
-        CSSHARP_CORE_ERROR("Failed to enqueue task for next world update!");
     }
 }
 

--- a/src/core/managers/server_manager.h
+++ b/src/core/managers/server_manager.h
@@ -19,7 +19,6 @@
 #include "core/globals.h"
 #include "core/global_listener.h"
 #include "scripting/script_engine.h"
-#include <concurrentqueue.h>
 
 #include "core/game_system.h"
 
@@ -35,7 +34,6 @@ class ServerManager : public GlobalClass
     void OnShutdown() override;
     void* GetEconItemSystem();
     bool IsPaused();
-    void AddTaskForNextWorldUpdate(std::function<void()>&& task);
     void OnPrecacheResources(IEntityResourceManifest* pResourceManifest);
 
     ScriptCallback* on_server_pre_entity_think;
@@ -59,8 +57,6 @@ class ServerManager : public GlobalClass
     ScriptCallback* on_server_pre_world_update;
 
     ScriptCallback* on_server_precache_resources;
-
-    moodycamel::ConcurrentQueue<std::function<void()>> m_nextWorldUpdateTasks{ 4096 };
 };
 
 } // namespace counterstrikesharp

--- a/src/mm_plugin.h
+++ b/src/mm_plugin.h
@@ -25,7 +25,6 @@
 #include <sh_vector.h>
 #include <vector>
 #include "entitysystem.h"
-#include "concurrentqueue.h"
 
 namespace counterstrikesharp {
 class ScriptCallback;
@@ -49,7 +48,6 @@ class CounterStrikeSharpMMPlugin : public ISmmPlugin, public IMetamodListener
     void OnLevelShutdown() override;
     void Hook_GameFrame(bool simulating, bool bFirstTick, bool bLastTick);
     void Hook_StartupServer(const GameSessionConfiguration_t& config, ISource2WorldSession*, const char*);
-    void AddTaskForNextFrame(std::function<void()>&& task);
 
     void Hook_RegisterLoopMode(const char* pszLoopModeName, ILoopModeFactory* pLoopModeFactory, void** ppGlobalPointer);
     int Hook_LoadEventsFromFile(const char* filename, bool bSearchAll);
@@ -64,9 +62,6 @@ class CounterStrikeSharpMMPlugin : public ISmmPlugin, public IMetamodListener
     const char* GetVersion() override;
     const char* GetDate() override;
     const char* GetLogTag() override;
-
-  private:
-    moodycamel::ConcurrentQueue<std::function<void()>> m_nextTasks{ 4096 };
 };
 
 static ScriptCallback* on_activate_callback;

--- a/src/scripting/natives/natives_engine.cpp
+++ b/src/scripting/natives/natives_engine.cpp
@@ -146,26 +146,6 @@ float GetSoundDuration(ScriptContext& script_context)
 
 double GetTickedTime(ScriptContext& script_context) { return globals::timerSystem.GetTickedTime(); }
 
-void QueueTaskForNextFrame(ScriptContext& script_context)
-{
-    auto func = script_context.GetArgument<void*>(0);
-
-    typedef void(voidfunc)(void);
-    globals::mmPlugin->AddTaskForNextFrame([func]() {
-        reinterpret_cast<voidfunc*>(func)();
-    });
-}
-
-void QueueTaskForNextWorldUpdate(ScriptContext& script_context)
-{
-    auto func = script_context.GetArgument<void*>(0);
-
-    typedef void(voidfunc)(void);
-    globals::serverManager.AddTaskForNextWorldUpdate([func]() {
-        reinterpret_cast<voidfunc*>(func)();
-    });
-}
-
 void QueueTaskForFrame(ScriptContext& script_context)
 {
     auto tick = script_context.GetArgument<int>(0);
@@ -289,8 +269,6 @@ REGISTER_NATIVES(engine, {
     // ScriptEngine::RegisterNativeHandler("EMIT_SOUND", EmitSound);
 
     ScriptEngine::RegisterNativeHandler("GET_TICKED_TIME", GetTickedTime);
-    ScriptEngine::RegisterNativeHandler("QUEUE_TASK_FOR_NEXT_FRAME", QueueTaskForNextFrame);
-    ScriptEngine::RegisterNativeHandler("QUEUE_TASK_FOR_NEXT_WORLD_UPDATE", QueueTaskForNextWorldUpdate);
     ScriptEngine::RegisterNativeHandler("QUEUE_TASK_FOR_FRAME", QueueTaskForFrame);
     ScriptEngine::RegisterNativeHandler("GET_VALVE_INTERFACE", GetValveInterface);
     ScriptEngine::RegisterNativeHandler("GET_COMMAND_PARAM_VALUE", GetCommandParamValue);

--- a/src/scripting/natives/natives_engine.yaml
+++ b/src/scripting/natives/natives_engine.yaml
@@ -22,9 +22,7 @@ TRACE_FILTER_PROXY_SET_TRACE_TYPE_CALLBACK: trace_filter:pointer, callback:point
 TRACE_FILTER_PROXY_SET_SHOULD_HIT_ENTITY_CALLBACK: trace_filter:pointer, callback:pointer -> void
 NEW_TRACE_RESULT: -> pointer
 GET_TICKED_TIME: -> double
-QUEUE_TASK_FOR_NEXT_FRAME: callback:func -> void
 QUEUE_TASK_FOR_FRAME: tick:int, callback:func -> void
-QUEUE_TASK_FOR_NEXT_WORLD_UPDATE: callback:func -> void
 GET_VALVE_INTERFACE: interfaceType:int, interfaceName:string -> pointer
 GET_COMMAND_PARAM_VALUE: param:string, dataType:DataType_t, defaultValue:any -> any
 PRINT_TO_SERVER_CONSOLE: msg:string -> void


### PR DESCRIPTION
## Move NextFrame queue to managed .NET side

During extensive testing of `NextFrame` and related scheduling code, I benchmarked using a .NET `ConcurrentQueue<T>` instead of the current C++ concurrent queue implementation.

### Results

- **Native C++ approach:** Queuing and resolving 100,000 NextFrame tasks took ~300ms on average (mainly due to P/Invoke overhead & FunctionReference memory allocations)
- **Managed .NET approach:** The same workload completed in 5–20ms (variance depends on where in the frame the benchmark was queued)

This is roughly a 50x improvement by moving the queue storage to the .NET side and having a managed listener drain the queue each frame.