### PR TITLE
feat: allow retrieval of schema data on non-main thread

### DIFF
--- a/managed/CounterStrikeSharp.Tests.Native/SchemaTests.cs
+++ b/managed/CounterStrikeSharp.Tests.Native/SchemaTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
@@ -14,7 +15,19 @@ public class SchemaTests
     {
         var offset = NativeAPI.GetSchemaOffset("CBaseEntity", "m_iHealth");
 
-        Assert.True(offset > 0, $"Schema offset for m_iHealth should be positive, got {offset}");
+        Assert.Equal(1464, offset); // Hardcode for now, this may change but I want to know if it changes
+    }
+
+    [Fact]
+    public async Task GetSchemaOffset_CanRunOnAnotherThread()
+    {
+        await Task.Run(async () =>
+        {
+            await Task.Yield();
+            Assert.NotEqual(Thread.CurrentThread.ManagedThreadId, NativeTestsPlugin.gameThreadId);
+            var offset = NativeAPI.GetSchemaOffset("CBaseEntity", "m_iHealth");
+            Assert.True(offset > 0);
+        });
     }
 
     [Fact]

--- a/src/mm_plugin.cpp
+++ b/src/mm_plugin.cpp
@@ -55,6 +55,7 @@ DLL_EXPORT void InvokeNative(counterstrikesharp::fxNativeContext& context)
     if (context.nativeIdentifier == 0) return;
 
     if (context.nativeIdentifier != counterstrikesharp::hash_string_const("QUEUE_TASK_FOR_FRAME") &&
+        context.nativeIdentifier != counterstrikesharp::hash_string_const("GET_SCHEMA_OFFSET") &&
         counterstrikesharp::globals::gameThreadId != std::this_thread::get_id())
     {
         counterstrikesharp::ScriptContextRaw scriptContext(context);


### PR DESCRIPTION
Allows the `GET_SCHEMA_OFFSET` native to be run off the main thread as I think it should be fairly safe and from my testing functioned okay.