### PR TITLE
Update signatures for CCSPlayerPawnBase and CCSGameRules

### DIFF
--- a/configs/addons/counterstrikesharp/gamedata/gamedata.json
+++ b/configs/addons/counterstrikesharp/gamedata/gamedata.json
@@ -42,7 +42,7 @@
   "CCSPlayerPawnBase_PostThink": {
     "signatures": {
       "library": "server",
-      "windows": "48 ? ? 55 53 56 57 41 ? 48 ? ? ? 48 ? ? ? ? ? ? 4C 89 68",
+      "windows": "48 8B C4 55 53 56 57 41 54 48 8D 68 ? 48 81 EC ? ? ? ? 4C 89 68 ? 48 8B F9",
       "linux": "55 48 89 E5 41 57 49 89 FF 41 56 41 55 41 54 53 48 81 EC ? ? ? ? E8 ? ? ? ? 41 80 BF"
     }
   },
@@ -122,7 +122,7 @@
   "CCSGameRules_TerminateRound": {
     "signatures": {
       "library": "server",
-      "windows": "48 8B C4 4C 89 48 ? 48 89 48 ? 55 56",
+      "windows": "48 8B C4 4C 89 48 ? 48 89 48 ? 55 56 41 56",
       "linux": "55 48 89 E5 41 57 41 56 49 89 FE 41 55 41 54 53 48 81 EC ? ? ? ? 48 8D 05 ? ? ? ? F3 0F 11 85"
     }
   },


### PR DESCRIPTION
These two signatures was invalid due to multiple matches for Windows.