### PR TITLE
Refactor plugin lifecycle cleanup in PluginContext

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs
@@ -41,25 +41,26 @@ namespace CounterStrikeSharp.API.Core.Plugin
         void TerminateSelf(string reason);
     }
 
-    public class PluginContext : IPluginContext, ISelfPluginControl
+    public class PluginContext : IPluginContext, ISelfPluginControl, IDisposable
     {
         public PluginState State { get; set; } = PluginState.Unregistered;
         public IPlugin Plugin { get; private set; }
 
-        private PluginLoader Loader { get; set; }
+        private PluginLoader? Loader { get; set; }
 
-        private ServiceProvider ServiceProvider { get; set; }
+        private ServiceProvider? ServiceProvider { get; set; }
 
         public int PluginId { get; }
 
         private readonly ICommandManager _commandManager;
         private readonly IScriptHostConfiguration _hostConfiguration;
         private readonly string _path;
-        private readonly FileSystemWatcher _fileWatcher;
+        private FileSystemWatcher? _fileWatcher;
+        private bool _disposed;
         private readonly IServiceProvider _applicationServiceProvider;
 
         public string FilePath => _path;
-        private IServiceScope _serviceScope;
+        private IServiceScope? _serviceScope;
 
         public string TerminationReason { get; private set; }
 
@@ -74,6 +75,7 @@ namespace CounterStrikeSharp.API.Core.Plugin
             _hostConfiguration = hostConfiguration;
             _path = path;
             PluginId = id;
+            _applicationServiceProvider = applicationServiceProvider;
 
             Loader = PluginLoader.CreateFromAssemblyFile(path,
                 new[]
@@ -108,7 +110,7 @@ namespace CounterStrikeSharp.API.Core.Plugin
 
                 _fileWatcher.Filter = "*.dll";
                 _fileWatcher.EnableRaisingEvents = true;
-                Loader.Reloaded += async (s, e) => await OnReloadedAsync(s, e);
+                Loader.Reloaded += OnReloadedAsync;
             }
         }
 
@@ -261,29 +263,92 @@ namespace CounterStrikeSharp.API.Core.Plugin
 
         public void Unload(bool hotReload = false)
         {
-            if (State == PluginState.Unloaded) return;
+            if (State == PluginState.Unloaded)
+                return;
 
             State = PluginState.Unloaded;
             var cachedName = Plugin.ModuleName;
 
-            _logger.LogInformation("Unloading plugin {Name}", Plugin.ModuleName);
+            _logger.LogInformation("Unloading plugin {Name}", cachedName);
 
             try
             {
                 Plugin.Unload(hotReload);
             }
-            catch
+            catch (Exception ex)
             {
-                _logger.LogError("Failed to unload {Name} during error recovery, forcing cleanup", Plugin.ModuleName);
-                return;
+                _logger.LogError(ex, "Failed to unload {Name} during error recovery, forcing cleanup", cachedName);
             }
             finally
             {
-                Plugin.Dispose();
-                _serviceScope.Dispose();
+                try
+                {
+                    Plugin.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to dispose plugin instance {Name}", cachedName);
+                }
+
+                _serviceScope?.Dispose();
+                _serviceScope = null;
+
+                try
+                {
+                    ServiceProvider?.Dispose();
+                    ServiceProvider = null;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to dispose service provider for plugin {Path}", _path);
+                    ServiceProvider = null;
+                }
+            }
+
+            if (!hotReload)
+            {
+                Dispose();
             }
 
             _logger.LogInformation("Finished unloading plugin {Name}", cachedName);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
+            try
+            {
+                if (_fileWatcher != null)
+                {
+                    _fileWatcher.EnableRaisingEvents = false;
+                    _fileWatcher.Dispose();
+                    _fileWatcher = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to dispose file watcher for plugin {Path}", _path);
+                _fileWatcher = null;
+            }
+
+            try
+            {
+                if (Loader != null)
+                {
+                    Loader.Reloaded -= OnReloadedAsync;
+                    Loader.Dispose();
+                    Loader = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to dispose loader for plugin {Path}", _path);
+                Loader = null;
+            }
         }
 
         public void TerminateWithReason(string reason)
@@ -320,7 +385,7 @@ namespace CounterStrikeSharp.API.Core.Plugin
 
                 // **Failsafe mechanism** ensures execution termination
                 // Prevents control flow leakage back to plugin execution context
-                throw new NotImplementedException();
+                throw new PluginTerminationException(reason);
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR improves plugin lifecycle cleanup in `PluginContext` by making disposal explicit, idempotent, and centralized.

## Why

`PluginContext` currently owns several long-lived resources during a plugin's lifetime:

- the plugin instance
- the plugin DI scope
- the plugin root `ServiceProvider`
- the plugin loader
- hot-reload related event subscriptions
- a `FileSystemWatcher` when hot reload is enabled

At the moment, unload/cleanup behavior is not fully centralized, which makes repeated unload/reload cycles harder to reason about and increases the risk of leaked resources.

This PR keeps the scope intentionally small and only focuses on `PluginContext` resource ownership and cleanup.

## Changes

- Implement `IDisposable` on `PluginContext`
- Make owned-resource cleanup explicit and idempotent
- Dispose the plugin file watcher cleanly
- Unsubscribe `Loader.Reloaded` before disposing the loader
- Dispose the root `ServiceProvider`
- Replace the `NotImplementedException` used in self-termination with `PluginTerminationException`

## Non-goals

This PR does **not**:
- change `PluginManager` ownership rules
- refactor `css_plugins unload/reload`
- change bootstrap/host builder behavior
- redesign contextual dependency resolution

Those changes are better handled in follow-up PRs.

## Testing

- [ ] Load a plugin normally
- [ ] Unload a plugin once and verify no exceptions
- [ ] Reload the same plugin multiple times
- [ ] Replace/delete the plugin DLL and confirm hot-reload/unload still behaves correctly
- [ ] Verify no watcher / file lock regressions

## Files to review

- `managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs`