### PR TITLE
perf: improve ScriptContext performance

### DIFF
--- a/eng/run-benchmarks.ts
+++ b/eng/run-benchmarks.ts
@@ -102,7 +102,7 @@ await poll(restartTimeout, 5_000, "Server not ready yet", async () => {
 });
 
 $.logStep("Server is back online.");
-await $.sleep(5_000);
+await $.sleep("10s");
 
 // ── Run benchmarks ──────────────────────────────────────────────────────
 

--- a/managed/CounterStrikeSharp.API/BaseNative.cs
+++ b/managed/CounterStrikeSharp.API/BaseNative.cs
@@ -1,3 +1,4 @@
+using FastGenericNew;
 /*
  *  This file is part of CounterStrikeSharp.
  *  CounterStrikeSharp is free software: you can redistribute it and/or modify
@@ -67,7 +68,7 @@ namespace CounterStrikeSharp.API
         /// <returns></returns>
         public T As<T>() where T : NativeObject
         {
-            return (T)Activator.CreateInstance(typeof(T), this.Handle);
+            return FastNew.CreateInstance<T, IntPtr>(this.Handle);
         }
     }
 }

--- a/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CBaseEntity.cs
@@ -1,3 +1,4 @@
+using FastGenericNew;
 using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -87,7 +88,7 @@ public partial class CBaseEntity
     {
         Guard.IsValidEntity(this);
 
-        return (T)Activator.CreateInstance(typeof(T), Marshal.ReadIntPtr(SubclassID.Handle + 4));
+        return FastNew.CreateInstance<T, IntPtr>(Marshal.ReadIntPtr(SubclassID.Handle + 4));
     }
 
     /// <summary>

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
@@ -1,3 +1,4 @@
+using FastGenericNew;
 ﻿/*
  *  This file is part of CounterStrikeSharp.
  *  CounterStrikeSharp is free software: you can redistribute it and/or modify
@@ -54,7 +55,7 @@ public partial class CCSPlayer_ItemServices
         if (pointer == IntPtr.Zero)
             return null;
 
-        return (T)Activator.CreateInstance(typeof(T), pointer)!;
+        return FastNew.CreateInstance<T, IntPtr>(pointer);
     }
 
     public AcquireResult CanAcquire(CEconItemView itemView, AcquireMethod method, IntPtr unknown = 0)

--- a/managed/CounterStrikeSharp.API/Core/Model/NetworkedVector.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/NetworkedVector.cs
@@ -1,3 +1,4 @@
+using FastGenericNew;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -29,7 +30,7 @@ public partial class NetworkedVector<T> : NativeObject, IReadOnlyCollection<T>
                 throw new NotSupportedException("Networked vectors currently only support CHandle<T>");
             }
 
-            return (T)Activator.CreateInstance(typeof(T), NativeAPI.GetNetworkVectorElementAt(Handle, index));
+            return FastNew.CreateInstance<T, IntPtr>(NativeAPI.GetNetworkVectorElementAt(Handle, index));
         }
     }
 

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -32,6 +32,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 using CounterStrikeSharp.API.Modules.Utils;
+using FastGenericNew;
 
 namespace CounterStrikeSharp.API.Core
 {
@@ -558,6 +559,20 @@ namespace CounterStrikeSharp.API.Core
 			fixed (fxScriptContext* cxt = &m_extContext)
 			{
 				return *(T*)(&cxt->result[0]);
+			}
+		}
+
+		/// <summary>
+		/// Reads a pointer result from the context and creates a NativeObject-derived
+		/// instance using FastGenericNew. Avoids Activator.CreateInstance overhead.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public unsafe T GetResultNativeObject<T>()
+		{
+			fixed (fxScriptContext* cxt = &m_extContext)
+			{
+				var pointer = *(IntPtr*)(&cxt->result[0]);
+				return FastNew.CreateInstance<T, IntPtr>(pointer);
 			}
 		}
 

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -61,11 +61,18 @@ namespace CounterStrikeSharp.API.Core
 
 		public static ScriptContext GlobalScriptContext
 		{
+			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			get
 			{
-				if (_globalScriptContext == null) _globalScriptContext = new ScriptContext();
-				return _globalScriptContext;
+				return _globalScriptContext ?? InitGlobalScriptContext();
 			}
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static ScriptContext InitGlobalScriptContext()
+		{
+			_globalScriptContext = new ScriptContext();
+			return _globalScriptContext;
 		}
 
 		public unsafe ScriptContext()
@@ -87,6 +94,7 @@ namespace CounterStrikeSharp.API.Core
 
 		internal bool isCleanupLocked = false;
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[SecuritySafeCritical]
 		public void Reset()
 		{
@@ -103,6 +111,7 @@ namespace CounterStrikeSharp.API.Core
 			//CleanUp();
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[SecuritySafeCritical]
 		public void Invoke()
 		{
@@ -118,6 +127,7 @@ namespace CounterStrikeSharp.API.Core
 			InvokeNativeInternal();
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[SecurityCritical]
 		private void InvokeNativeInternal()
 		{

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -36,590 +36,558 @@ using FastGenericNew;
 
 namespace CounterStrikeSharp.API.Core
 {
-	public class NativeException : Exception
-	{
-		public NativeException(string message) : base(message)
-		{
-		}
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	[Serializable]
-	public unsafe struct fxScriptContext
-	{
-		public int numArguments;
-		public int numResults;
-		public int hasError;
-
-		public ulong nativeIdentifier;
-		public fixed byte functionData[8 * 32];
-		public fixed byte result[8];
-	}
-
-	public class ScriptContext
-	{
-		[ThreadStatic] private static ScriptContext _globalScriptContext;
-
-		public static ScriptContext GlobalScriptContext
-		{
-			[MethodImpl(MethodImplOptions.AggressiveInlining)]
-			get
-			{
-				return _globalScriptContext ?? InitGlobalScriptContext();
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.NoInlining)]
-		private static ScriptContext InitGlobalScriptContext()
-		{
-			_globalScriptContext = new ScriptContext();
-			return _globalScriptContext;
-		}
-
-		public unsafe ScriptContext()
-		{
-		}
-
-		public unsafe ScriptContext(fxScriptContext* context)
-		{
-			m_extContext = *context;
-		}
-
-		private readonly ConcurrentQueue<Action> ms_finalizers = new ConcurrentQueue<Action>();
-
-		private readonly object ms_lock = new object();
-
-		// Pinned arena for string arguments — avoids per-call AllocHGlobal + finalizer overhead.
-		// 8 KB covers most native calls (32 args × ~256 bytes each). Overflows fall back to AllocHGlobal.
-		private const int StringArenaCapacity = 8192;
-		private readonly byte[] _stringArena = GC.AllocateUninitializedArray<byte>(StringArenaCapacity, pinned: true);
-		private int _stringArenaOffset;
-
-		internal object Lock => ms_lock;
-
-		internal fxScriptContext m_extContext = new fxScriptContext();
-
-		internal bool isCleanupLocked = false;
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[SecuritySafeCritical]
-		public void Reset()
-		{
-			InternalReset();
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[SecurityCritical]
-		private void InternalReset()
-		{
-			m_extContext.numArguments = 0;
-			m_extContext.numResults = 0;
-			m_extContext.hasError = 0;
-			_stringArenaOffset = 0;
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[SecuritySafeCritical]
-		public void Invoke()
-		{
-			if (!isCleanupLocked)
-			{
-				isCleanupLocked = true;
-				InvokeNativeInternal();
-				GlobalCleanUp();
-				isCleanupLocked = false;
-				return;
-			}
-
-			InvokeNativeInternal();
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[SecurityCritical]
-		private void InvokeNativeInternal()
-		{
-			unsafe
-			{
-				fixed (fxScriptContext* cxt = &m_extContext)
-				{
-					Helpers.InvokeNative(new IntPtr(cxt));
-				}
-			}
-		}
-
-		public unsafe byte[] GetBytes()
-		{
-			fixed (fxScriptContext* context = &m_extContext)
-			{
-				byte[] arr = new byte[8 * 32];
-				Marshal.Copy((IntPtr)context->functionData, arr, 0, 8 * 32);
-
-				return arr;
-			}
-		}
-
-		public unsafe IntPtr GetContextUnderlyingAddress()
-		{
-			fixed (fxScriptContext* context = &m_extContext)
-			{
-				return (IntPtr)context;
-			}
-		}
-
-		[SecuritySafeCritical]
-		public void Push(object arg)
-		{
-			PushInternal(arg);
-		}
-
-		[SecuritySafeCritical]
-		public unsafe void SetResult(object arg, fxScriptContext* cxt)
-		{
-			SetResultInternal(cxt, arg);
-		}
-
-		[SecurityCritical]
-		private unsafe void PushInternal(object arg)
-		{
-			fixed (fxScriptContext* context = &m_extContext)
-			{
-				Push(context, arg);
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		[SecurityCritical]
-		public unsafe void SetIdentifier(ulong arg)
-		{
-			fixed (fxScriptContext* context = &m_extContext)
-			{
-				context->nativeIdentifier = arg;
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public unsafe void CheckErrors()
-		{
-			if (m_extContext.hasError != 0)
-			{
-				ThrowNativeError();
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.NoInlining)]
-		private void ThrowNativeError()
-		{
-			string error = GetResult<string>();
-			Reset();
-			throw new NativeException(error);
-		}
-
-		[SecurityCritical]
-		internal unsafe void Push(fxScriptContext* context, object arg)
-		{
-			if (arg == null)
-			{
-				arg = 0;
-			}
-
-			if (arg.GetType().IsEnum)
-			{
-				arg = Convert.ChangeType(arg, arg.GetType().GetEnumUnderlyingType());
-			}
-
-			if (arg is string)
-			{
-				var str = (string)Convert.ChangeType(arg, typeof(string));
-				PushString(context, str);
-
-				return;
-			}
-			else if (arg is InputArgument ia)
-			{
-				Push(context, ia.Value);
-
-				return;
-			}
-			else if (arg is IMarshalToNative marshalToNative)
-			{
-				foreach (var value in marshalToNative.GetNativeObject())
-				{
-					Push(context, value);
-				}
-
-				return;
-			}
-			else if (arg is NativeObject nativeObject)
-			{
-				Push(context, (InputArgument)nativeObject);
-				return;
-			}
-			else if (arg is NativeEntity nativeValue)
-			{
-				Push(context, (InputArgument)nativeValue);
-				return;
-			}
-
-			if (Marshal.SizeOf(arg.GetType()) <= 8)
-			{
-				PushUnsafe(context, arg);
-			}
-
-			context->numArguments++;
-		}
-
-		[SecurityCritical]
-		internal unsafe void SetResultInternal(fxScriptContext* context, object arg)
-		{
-			if (arg == null)
-			{
-				arg = 0;
-			}
-
-			if (arg.GetType().IsEnum)
-			{
-				arg = Convert.ChangeType(arg, arg.GetType().GetEnumUnderlyingType());
-			}
-
-			if (arg is string)
-			{
-				var str = (string)Convert.ChangeType(arg, typeof(string));
-				SetResultString(context, str);
-
-				return;
-			}
-			else if (arg is InputArgument ia)
-			{
-				SetResultInternal(context, ia.Value);
-
-				return;
-			}
-
-			if (Marshal.SizeOf(arg.GetType()) <= 8)
-			{
-				SetResultUnsafe(context, arg);
-			}
-		}
-
-		[SecurityCritical]
-		internal unsafe void PushUnsafe(fxScriptContext* cxt, object arg)
-		{
-			*(long*)(&cxt->functionData[8 * cxt->numArguments]) = 0;
-			Marshal.StructureToPtr(arg, new IntPtr(cxt->functionData + (8 * cxt->numArguments)), true);
-		}
-
-		/// <summary>
-		/// Pushes a primitive/unmanaged value directly into the context's function
-		/// data buffer without boxing or Marshal.StructureToPtr overhead.
-		/// </summary>
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public unsafe void PushPrimitive<T>(T value) where T : unmanaged
-		{
-			fixed (fxScriptContext* cxt = &m_extContext)
-			{
-				*(long*)(&cxt->functionData[8 * cxt->numArguments]) = 0;
-				*(T*)(&cxt->functionData[8 * cxt->numArguments]) = value;
-				cxt->numArguments++;
-			}
-		}
-
-		[SecurityCritical]
-		internal unsafe void SetResultUnsafe(fxScriptContext* cxt, object arg)
-		{
-			*(long*)(&cxt->result[0]) = 0;
-			Marshal.StructureToPtr(arg, new IntPtr(cxt->result), true);
-		}
-
-		[SecurityCritical]
-		internal unsafe void PushString(string str)
-		{
-			fixed (fxScriptContext* cxt = &m_extContext)
-			{
-				PushString(cxt, str);
-			}
-		}
-
-		[SecurityCritical]
-		internal unsafe void PushString(fxScriptContext* cxt, string str)
-		{
-			var ptr = IntPtr.Zero;
-
-			if (str != null)
-			{
-				// Encode directly into the pinned arena when possible.
-				int maxBytes = Encoding.UTF8.GetMaxByteCount(str.Length);
-				int arenaRemaining = StringArenaCapacity - _stringArenaOffset;
-
-				if (maxBytes + 1 <= arenaRemaining)
-				{
-					// Fast path: write into pinned arena (no alloc, no finalizer)
-					fixed (byte* arenaBase = &_stringArena[_stringArenaOffset])
-					{
-						int written;
-						fixed (char* chars = str)
-						{
-							written = Encoding.UTF8.GetBytes(chars, str.Length, arenaBase, arenaRemaining);
-						}
-						arenaBase[written] = 0; // null-terminate
-						ptr = (IntPtr)arenaBase;
-						_stringArenaOffset += written + 1;
-					}
-				}
-				else
-				{
-					// Overflow: fall back to AllocHGlobal
-					var b = Encoding.UTF8.GetBytes(str);
-					ptr = Marshal.AllocHGlobal(b.Length + 1);
-					Marshal.Copy(b, 0, ptr, b.Length);
-					Marshal.WriteByte(ptr, b.Length, 0);
-					ms_finalizers.Enqueue(() => Free(ptr));
-				}
-			}
-
-			*(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = ptr;
-			cxt->numArguments++;
-		}
-
-		[SecurityCritical]
-		internal unsafe void SetResultString(fxScriptContext* cxt, string str)
-		{
-			var ptr = IntPtr.Zero;
-
-			if (str != null)
-			{
-				var b = Encoding.UTF8.GetBytes(str);
-
-				ptr = Marshal.AllocHGlobal(b.Length + 1);
-
-				Marshal.Copy(b, 0, ptr, b.Length);
-				Marshal.WriteByte(ptr, b.Length, 0);
-
-				ms_finalizers.Enqueue(() => Free(ptr));
-			}
-
-			unsafe
-			{
-				*(IntPtr*)(&cxt->result[8]) = ptr;
-			}
-		}
-
-		[SecuritySafeCritical]
-		private void Free(IntPtr ptr)
-		{
-			Marshal.FreeHGlobal(ptr);
-		}
-
-		[SecuritySafeCritical]
-		public T GetArgument<T>(int index)
-		{
-			return (T)GetArgument(typeof(T), index);
-		}
-
-		[SecuritySafeCritical]
-		public object GetArgument(Type type, int index)
-		{
-			return GetArgumentHelper(type, index);
-		}
-
-		[SecurityCritical]
-		internal unsafe object GetArgument(fxScriptContext* cxt, Type type, int index)
-		{
-			return GetArgumentHelper(cxt, type, index);
-		}
-
-		[SecurityCritical]
-		private unsafe object GetArgumentHelper(Type type, int index)
-		{
-			fixed (fxScriptContext* cxt = &m_extContext)
-			{
-				return GetArgumentHelper(cxt, type, index);
-			}
-		}
-
-		[SecurityCritical]
-		private unsafe object GetArgumentHelper(fxScriptContext* context, Type type, int index)
-		{
-			return GetResult(type, &context->functionData[index * 8]);
-		}
-
-		[SecuritySafeCritical]
-		public T GetResult<T>()
-		{
-			return (T)GetResult(typeof(T));
-		}
-
-		[SecuritySafeCritical]
-		public object GetResult(Type type)
-		{
-			return GetResultHelper(type);
-		}
-
-		[SecurityCritical]
-		internal unsafe object GetResult(fxScriptContext* cxt, Type type)
-		{
-			return GetResultHelper(cxt, type);
-		}
-
-		[SecurityCritical]
-		private unsafe object GetResultHelper(Type type)
-		{
-			fixed (fxScriptContext* cxt = &m_extContext)
-			{
-				return GetResultHelper(cxt, type);
-			}
-		}
-
-		[SecurityCritical]
-		private unsafe object GetResultHelper(fxScriptContext* context, Type type)
-		{
-			return GetResult(type, &context->result[0]);
-		}
-
-		[SecurityCritical]
-		internal unsafe object GetResult(Type type, byte* ptr)
-		{
-			if (type == typeof(string))
-			{
-				var nativeUtf8 = *(IntPtr*)&ptr[0];
-
-				if (nativeUtf8 == IntPtr.Zero)
-				{
-					return null;
-				}
-
-				var len = 0;
-				while (Marshal.ReadByte(nativeUtf8, len) != 0)
-				{
-					++len;
-				}
-
-				var buffer = new byte[len];
-				Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
-				return Encoding.UTF8.GetString(buffer);
-			}
-
-			if (typeof(NativeObject).IsAssignableFrom(type))
-			{
-				var pointer = (IntPtr)GetResult(typeof(IntPtr), ptr);
-				return Activator.CreateInstance(type, pointer);
-			}
-
-			if (type == typeof(Color))
-			{
-				var pointer = (IntPtr)GetResult(typeof(IntPtr), ptr);
-				return Marshaling.ColorMarshaler.NativeToManaged(pointer);
-			}
-
-			// this one only works if the 'Raw'/uint is passed
-			// maybe do this with a marshaler?!
-			if (type == typeof(CEntityHandle))
-			{
-				return new CEntityHandle((uint)GetResult(typeof(uint), ptr));
-			}
-
-			if (type == typeof(object))
-			{
-				// var dataPtr = *(IntPtr*)&ptr[0];
-				// var dataLength = *(long*)&ptr[8];
-				//
-				// byte[] data = new byte[dataLength];
-				// Marshal.Copy(dataPtr, data, 0, (int)dataLength);
-
-				return null;
-				//return MsgPackDeserializer.Deserialize(data);
-			}
-
-			if (type.IsEnum)
-			{
-				return Enum.ToObject(type, GetResult(type.GetEnumUnderlyingType(), ptr));
-			}
-
-			if (Marshal.SizeOf(type) <= 8)
-			{
-				return GetResultInternal(type, ptr);
-			}
-
-			return null;
-		}
-
-		[SecurityCritical]
-		private unsafe object GetResultInternal(Type type, byte* ptr)
-		{
-			var obj = Marshal.PtrToStructure(new IntPtr(ptr), type);
-			return obj;
-		}
-
-		/// <summary>
-		/// Reads a primitive/unmanaged result directly from the context's result
-		/// buffer without Marshal.PtrToStructure or boxing overhead.
-		/// </summary>
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public unsafe T GetResultPrimitive<T>() where T : unmanaged
-		{
-			fixed (fxScriptContext* cxt = &m_extContext)
-			{
-				return *(T*)(&cxt->result[0]);
-			}
-		}
-
-		/// <summary>
-		/// Reads a pointer result from the context and creates a NativeObject-derived
-		/// instance using FastGenericNew. Avoids Activator.CreateInstance overhead.
-		/// </summary>
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public unsafe T GetResultNativeObject<T>()
-		{
-			fixed (fxScriptContext* cxt = &m_extContext)
-			{
-				var pointer = *(IntPtr*)(&cxt->result[0]);
-				return FastNew.CreateInstance<T, IntPtr>(pointer);
-			}
-		}
-
-
-		[SecurityCritical]
-		internal unsafe string ErrorHandler(byte* error)
-		{
-			if (error != null)
-			{
-				var errorStart = error;
-				int length = 0;
-
-				for (var p = errorStart; *p != 0; p++)
-				{
-					length++;
-				}
-
-				return Encoding.UTF8.GetString(errorStart, length);
-			}
-
-			return "Native invocation failed.";
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal void GlobalCleanUp()
-		{
-			if (!ms_finalizers.IsEmpty)
-			{
-				GlobalCleanUpSlow();
-			}
-		}
-
-		[MethodImpl(MethodImplOptions.NoInlining)]
-		private void GlobalCleanUpSlow()
-		{
-			lock (ms_lock)
-			{
-				while (ms_finalizers.TryDequeue(out var cb))
-				{
-					cb();
-				}
-			}
-		}
-
-		public override string ToString()
-		{
-			return $"ScriptContext{{numArgs={m_extContext.numArguments}}}";
-		}
-	}
+    public class NativeException : Exception
+    {
+        public NativeException(string message) : base(message)
+        {
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    [Serializable]
+    public unsafe struct fxScriptContext
+    {
+        public int numArguments;
+        public int numResults;
+        public int hasError;
+
+        public ulong nativeIdentifier;
+        public fixed byte functionData[8 * 32];
+        public fixed byte result[8];
+    }
+
+    public class ScriptContext
+    {
+        [ThreadStatic] private static ScriptContext _globalScriptContext;
+
+        public static ScriptContext GlobalScriptContext
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _globalScriptContext ?? InitGlobalScriptContext(); }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ScriptContext InitGlobalScriptContext()
+        {
+            _globalScriptContext = new ScriptContext();
+            return _globalScriptContext;
+        }
+
+        public unsafe ScriptContext()
+        {
+        }
+
+        public unsafe ScriptContext(fxScriptContext* context)
+        {
+            m_extContext = *context;
+        }
+
+        private readonly ConcurrentQueue<Action> ms_finalizers = new ConcurrentQueue<Action>();
+
+        private readonly object ms_lock = new object();
+
+        internal object Lock => ms_lock;
+
+        internal fxScriptContext m_extContext = new fxScriptContext();
+
+        internal bool isCleanupLocked = false;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SecuritySafeCritical]
+        public void Reset()
+        {
+            InternalReset();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SecurityCritical]
+        private void InternalReset()
+        {
+            m_extContext.numArguments = 0;
+            m_extContext.numResults = 0;
+            m_extContext.hasError = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SecuritySafeCritical]
+        public void Invoke()
+        {
+            if (!isCleanupLocked)
+            {
+                isCleanupLocked = true;
+                InvokeNativeInternal();
+                GlobalCleanUp();
+                isCleanupLocked = false;
+                return;
+            }
+
+            InvokeNativeInternal();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SecurityCritical]
+        private void InvokeNativeInternal()
+        {
+            unsafe
+            {
+                fixed (fxScriptContext* cxt = &m_extContext)
+                {
+                    Helpers.InvokeNative(new IntPtr(cxt));
+                }
+            }
+        }
+
+        public unsafe byte[] GetBytes()
+        {
+            fixed (fxScriptContext* context = &m_extContext)
+            {
+                byte[] arr = new byte[8 * 32];
+                Marshal.Copy((IntPtr)context->functionData, arr, 0, 8 * 32);
+
+                return arr;
+            }
+        }
+
+        public unsafe IntPtr GetContextUnderlyingAddress()
+        {
+            fixed (fxScriptContext* context = &m_extContext)
+            {
+                return (IntPtr)context;
+            }
+        }
+
+        [SecuritySafeCritical]
+        public void Push(object arg)
+        {
+            PushInternal(arg);
+        }
+
+        [SecuritySafeCritical]
+        public unsafe void SetResult(object arg, fxScriptContext* cxt)
+        {
+            SetResultInternal(cxt, arg);
+        }
+
+        [SecurityCritical]
+        private unsafe void PushInternal(object arg)
+        {
+            fixed (fxScriptContext* context = &m_extContext)
+            {
+                Push(context, arg);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SecurityCritical]
+        public unsafe void SetIdentifier(ulong arg)
+        {
+            fixed (fxScriptContext* context = &m_extContext)
+            {
+                context->nativeIdentifier = arg;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void CheckErrors()
+        {
+            if (m_extContext.hasError != 0)
+            {
+                string error = GetResult<string>();
+                Reset();
+                throw new NativeException(error);
+            }
+        }
+
+        [SecurityCritical]
+        internal unsafe void Push(fxScriptContext* context, object arg)
+        {
+            if (arg == null)
+            {
+                arg = 0;
+            }
+
+            if (arg.GetType().IsEnum)
+            {
+                arg = Convert.ChangeType(arg, arg.GetType().GetEnumUnderlyingType());
+            }
+
+            if (arg is string)
+            {
+                var str = (string)Convert.ChangeType(arg, typeof(string));
+                PushString(context, str);
+
+                return;
+            }
+            else if (arg is InputArgument ia)
+            {
+                Push(context, ia.Value);
+
+                return;
+            }
+            else if (arg is IMarshalToNative marshalToNative)
+            {
+                foreach (var value in marshalToNative.GetNativeObject())
+                {
+                    Push(context, value);
+                }
+
+                return;
+            }
+            else if (arg is NativeObject nativeObject)
+            {
+                Push(context, (InputArgument)nativeObject);
+                return;
+            }
+            else if (arg is NativeEntity nativeValue)
+            {
+                Push(context, (InputArgument)nativeValue);
+                return;
+            }
+
+            if (Marshal.SizeOf(arg.GetType()) <= 8)
+            {
+                PushUnsafe(context, arg);
+            }
+
+            context->numArguments++;
+        }
+
+        [SecurityCritical]
+        internal unsafe void SetResultInternal(fxScriptContext* context, object arg)
+        {
+            if (arg == null)
+            {
+                arg = 0;
+            }
+
+            if (arg.GetType().IsEnum)
+            {
+                arg = Convert.ChangeType(arg, arg.GetType().GetEnumUnderlyingType());
+            }
+
+            if (arg is string)
+            {
+                var str = (string)Convert.ChangeType(arg, typeof(string));
+                SetResultString(context, str);
+
+                return;
+            }
+            else if (arg is InputArgument ia)
+            {
+                SetResultInternal(context, ia.Value);
+
+                return;
+            }
+
+            if (Marshal.SizeOf(arg.GetType()) <= 8)
+            {
+                SetResultUnsafe(context, arg);
+            }
+        }
+
+        [SecurityCritical]
+        internal unsafe void PushUnsafe(fxScriptContext* cxt, object arg)
+        {
+            *(long*)(&cxt->functionData[8 * cxt->numArguments]) = 0;
+            Marshal.StructureToPtr(arg, new IntPtr(cxt->functionData + (8 * cxt->numArguments)), true);
+        }
+
+        /// <summary>
+        /// Pushes a primitive/unmanaged value directly into the context's function
+        /// data buffer without boxing or Marshal.StructureToPtr overhead.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void PushPrimitive<T>(T value) where T : unmanaged
+        {
+            fixed (fxScriptContext* cxt = &m_extContext)
+            {
+                *(long*)(&cxt->functionData[8 * cxt->numArguments]) = 0;
+                *(T*)(&cxt->functionData[8 * cxt->numArguments]) = value;
+                cxt->numArguments++;
+            }
+        }
+
+        [SecurityCritical]
+        internal unsafe void SetResultUnsafe(fxScriptContext* cxt, object arg)
+        {
+            *(long*)(&cxt->result[0]) = 0;
+            Marshal.StructureToPtr(arg, new IntPtr(cxt->result), true);
+        }
+
+        [SecurityCritical]
+        internal unsafe void PushString(string str)
+        {
+            fixed (fxScriptContext* cxt = &m_extContext)
+            {
+                PushString(cxt, str);
+            }
+        }
+
+        [SecurityCritical]
+        internal unsafe void PushString(fxScriptContext* cxt, string str)
+        {
+            var ptr = IntPtr.Zero;
+
+            if (str != null)
+            {
+                var b = Encoding.UTF8.GetBytes(str);
+
+                ptr = Marshal.AllocHGlobal(b.Length + 1);
+
+                Marshal.Copy(b, 0, ptr, b.Length);
+                Marshal.WriteByte(ptr, b.Length, 0);
+
+                ms_finalizers.Enqueue(() => Free(ptr));
+            }
+
+            unsafe
+            {
+                *(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = ptr;
+            }
+
+            cxt->numArguments++;
+        }
+
+        [SecurityCritical]
+        internal unsafe void SetResultString(fxScriptContext* cxt, string str)
+        {
+            var ptr = IntPtr.Zero;
+
+            if (str != null)
+            {
+                var b = Encoding.UTF8.GetBytes(str);
+
+                ptr = Marshal.AllocHGlobal(b.Length + 1);
+
+                Marshal.Copy(b, 0, ptr, b.Length);
+                Marshal.WriteByte(ptr, b.Length, 0);
+
+                ms_finalizers.Enqueue(() => Free(ptr));
+            }
+
+            unsafe
+            {
+                *(IntPtr*)(&cxt->result[8]) = ptr;
+            }
+        }
+
+        [SecuritySafeCritical]
+        private void Free(IntPtr ptr)
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+
+        [SecuritySafeCritical]
+        public T GetArgument<T>(int index)
+        {
+            return (T)GetArgument(typeof(T), index);
+        }
+
+        [SecuritySafeCritical]
+        public object GetArgument(Type type, int index)
+        {
+            return GetArgumentHelper(type, index);
+        }
+
+        [SecurityCritical]
+        internal unsafe object GetArgument(fxScriptContext* cxt, Type type, int index)
+        {
+            return GetArgumentHelper(cxt, type, index);
+        }
+
+        [SecurityCritical]
+        private unsafe object GetArgumentHelper(Type type, int index)
+        {
+            fixed (fxScriptContext* cxt = &m_extContext)
+            {
+                return GetArgumentHelper(cxt, type, index);
+            }
+        }
+
+        [SecurityCritical]
+        private unsafe object GetArgumentHelper(fxScriptContext* context, Type type, int index)
+        {
+            return GetResult(type, &context->functionData[index * 8]);
+        }
+
+        [SecuritySafeCritical]
+        public T GetResult<T>()
+        {
+            return (T)GetResult(typeof(T));
+        }
+
+        [SecuritySafeCritical]
+        public object GetResult(Type type)
+        {
+            return GetResultHelper(type);
+        }
+
+        [SecurityCritical]
+        internal unsafe object GetResult(fxScriptContext* cxt, Type type)
+        {
+            return GetResultHelper(cxt, type);
+        }
+
+        [SecurityCritical]
+        private unsafe object GetResultHelper(Type type)
+        {
+            fixed (fxScriptContext* cxt = &m_extContext)
+            {
+                return GetResultHelper(cxt, type);
+            }
+        }
+
+        [SecurityCritical]
+        private unsafe object GetResultHelper(fxScriptContext* context, Type type)
+        {
+            return GetResult(type, &context->result[0]);
+        }
+
+        [SecurityCritical]
+        internal unsafe object GetResult(Type type, byte* ptr)
+        {
+            if (type == typeof(string))
+            {
+                var nativeUtf8 = *(IntPtr*)&ptr[0];
+
+                if (nativeUtf8 == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                var len = 0;
+                while (Marshal.ReadByte(nativeUtf8, len) != 0)
+                {
+                    ++len;
+                }
+
+                var buffer = new byte[len];
+                Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
+                return Encoding.UTF8.GetString(buffer);
+            }
+
+            if (typeof(NativeObject).IsAssignableFrom(type))
+            {
+                var pointer = (IntPtr)GetResult(typeof(IntPtr), ptr);
+                return Activator.CreateInstance(type, pointer);
+            }
+
+            if (type == typeof(Color))
+            {
+                var pointer = (IntPtr)GetResult(typeof(IntPtr), ptr);
+                return Marshaling.ColorMarshaler.NativeToManaged(pointer);
+            }
+
+            // this one only works if the 'Raw'/uint is passed
+            // maybe do this with a marshaler?!
+            if (type == typeof(CEntityHandle))
+            {
+                return new CEntityHandle((uint)GetResult(typeof(uint), ptr));
+            }
+
+            if (type == typeof(object))
+            {
+                // var dataPtr = *(IntPtr*)&ptr[0];
+                // var dataLength = *(long*)&ptr[8];
+                //
+                // byte[] data = new byte[dataLength];
+                // Marshal.Copy(dataPtr, data, 0, (int)dataLength);
+
+                return null;
+                //return MsgPackDeserializer.Deserialize(data);
+            }
+
+            if (type.IsEnum)
+            {
+                return Enum.ToObject(type, GetResult(type.GetEnumUnderlyingType(), ptr));
+            }
+
+            if (Marshal.SizeOf(type) <= 8)
+            {
+                return GetResultInternal(type, ptr);
+            }
+
+            return null;
+        }
+
+        [SecurityCritical]
+        private unsafe object GetResultInternal(Type type, byte* ptr)
+        {
+            var obj = Marshal.PtrToStructure(new IntPtr(ptr), type);
+            return obj;
+        }
+
+        /// <summary>
+        /// Reads a primitive/unmanaged result directly from the context's result
+        /// buffer without Marshal.PtrToStructure or boxing overhead.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe T GetResultPrimitive<T>() where T : unmanaged
+        {
+            fixed (fxScriptContext* cxt = &m_extContext)
+            {
+                return *(T*)(&cxt->result[0]);
+            }
+        }
+
+        /// <summary>
+        /// Reads a pointer result from the context and creates a NativeObject-derived
+        /// instance using FastGenericNew. Avoids Activator.CreateInstance overhead.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe T GetResultNativeObject<T>()
+        {
+            fixed (fxScriptContext* cxt = &m_extContext)
+            {
+                var pointer = *(IntPtr*)(&cxt->result[0]);
+                return FastNew.CreateInstance<T, IntPtr>(pointer);
+            }
+        }
+
+
+        [SecurityCritical]
+        internal unsafe string ErrorHandler(byte* error)
+        {
+            if (error != null)
+            {
+                var errorStart = error;
+                int length = 0;
+
+                for (var p = errorStart; *p != 0; p++)
+                {
+                    length++;
+                }
+
+                return Encoding.UTF8.GetString(errorStart, length);
+            }
+
+            return "Native invocation failed.";
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void GlobalCleanUp()
+        {
+            if (!ms_finalizers.IsEmpty)
+            {
+                GlobalCleanUpSlow();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GlobalCleanUpSlow()
+        {
+            lock (ms_lock)
+            {
+                while (ms_finalizers.TryDequeue(out var cb))
+                {
+                    cb();
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"ScriptContext{{numArgs={m_extContext.numArguments}}}";
+        }
+    }
 }

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -88,6 +88,12 @@ namespace CounterStrikeSharp.API.Core
 
 		private readonly object ms_lock = new object();
 
+		// Pinned arena for string arguments — avoids per-call AllocHGlobal + finalizer overhead.
+		// 8 KB covers most native calls (32 args × ~256 bytes each). Overflows fall back to AllocHGlobal.
+		private const int StringArenaCapacity = 8192;
+		private readonly byte[] _stringArena = GC.AllocateUninitializedArray<byte>(StringArenaCapacity, pinned: true);
+		private int _stringArenaOffset;
+
 		internal object Lock => ms_lock;
 
 		internal fxScriptContext m_extContext = new fxScriptContext();
@@ -108,7 +114,7 @@ namespace CounterStrikeSharp.API.Core
 			m_extContext.numArguments = 0;
 			m_extContext.numResults = 0;
 			m_extContext.hasError = 0;
-			//CleanUp();
+			_stringArenaOffset = 0;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -339,21 +345,37 @@ namespace CounterStrikeSharp.API.Core
 
 			if (str != null)
 			{
-				var b = Encoding.UTF8.GetBytes(str);
+				// Encode directly into the pinned arena when possible.
+				int maxBytes = Encoding.UTF8.GetMaxByteCount(str.Length);
+				int arenaRemaining = StringArenaCapacity - _stringArenaOffset;
 
-				ptr = Marshal.AllocHGlobal(b.Length + 1);
-
-				Marshal.Copy(b, 0, ptr, b.Length);
-				Marshal.WriteByte(ptr, b.Length, 0);
-
-				ms_finalizers.Enqueue(() => Free(ptr));
+				if (maxBytes + 1 <= arenaRemaining)
+				{
+					// Fast path: write into pinned arena (no alloc, no finalizer)
+					fixed (byte* arenaBase = &_stringArena[_stringArenaOffset])
+					{
+						int written;
+						fixed (char* chars = str)
+						{
+							written = Encoding.UTF8.GetBytes(chars, str.Length, arenaBase, arenaRemaining);
+						}
+						arenaBase[written] = 0; // null-terminate
+						ptr = (IntPtr)arenaBase;
+						_stringArenaOffset += written + 1;
+					}
+				}
+				else
+				{
+					// Overflow: fall back to AllocHGlobal
+					var b = Encoding.UTF8.GetBytes(str);
+					ptr = Marshal.AllocHGlobal(b.Length + 1);
+					Marshal.Copy(b, 0, ptr, b.Length);
+					Marshal.WriteByte(ptr, b.Length, 0);
+					ms_finalizers.Enqueue(() => Free(ptr));
+				}
 			}
 
-			unsafe
-			{
-				*(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = ptr;
-			}
-
+			*(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = ptr;
 			cxt->numArguments++;
 		}
 

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -82,7 +82,7 @@ namespace CounterStrikeSharp.API.Core
             m_extContext = *context;
         }
 
-        private readonly ConcurrentQueue<Action> ms_finalizers = new ConcurrentQueue<Action>();
+        private readonly ConcurrentQueue<IntPtr> ms_finalizers = new ConcurrentQueue<IntPtr>();
 
         private readonly object ms_lock = new object();
 
@@ -326,55 +326,44 @@ namespace CounterStrikeSharp.API.Core
         [SecurityCritical]
         internal unsafe void PushString(fxScriptContext* cxt, string str)
         {
-            var ptr = IntPtr.Zero;
-
-            if (str != null)
+            if (str == null)
             {
-                var b = Encoding.UTF8.GetBytes(str);
-
-                ptr = Marshal.AllocHGlobal(b.Length + 1);
-
-                Marshal.Copy(b, 0, ptr, b.Length);
-                Marshal.WriteByte(ptr, b.Length, 0);
-
-                ms_finalizers.Enqueue(() => Free(ptr));
+                *(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = IntPtr.Zero;
+                cxt->numArguments++;
+                return;
             }
 
-            unsafe
-            {
-                *(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = ptr;
-            }
+            int maxBytes = Encoding.UTF8.GetMaxByteCount(str.Length);
+            var ptr = Marshal.AllocHGlobal(maxBytes + 1);
 
+            var dest = new Span<byte>((void*)ptr, maxBytes + 1);
+            int written = Encoding.UTF8.GetBytes(str, dest);
+            dest[written] = 0;
+
+            ms_finalizers.Enqueue(ptr);
+
+            *(IntPtr*)(&cxt->functionData[8 * cxt->numArguments]) = ptr;
             cxt->numArguments++;
         }
 
         [SecurityCritical]
         internal unsafe void SetResultString(fxScriptContext* cxt, string str)
         {
-            var ptr = IntPtr.Zero;
-
-            if (str != null)
+            if (str == null)
             {
-                var b = Encoding.UTF8.GetBytes(str);
-
-                ptr = Marshal.AllocHGlobal(b.Length + 1);
-
-                Marshal.Copy(b, 0, ptr, b.Length);
-                Marshal.WriteByte(ptr, b.Length, 0);
-
-                ms_finalizers.Enqueue(() => Free(ptr));
+                *(IntPtr*)(&cxt->result[0]) = IntPtr.Zero;
+                return;
             }
 
-            unsafe
-            {
-                *(IntPtr*)(&cxt->result[8]) = ptr;
-            }
-        }
+            int maxBytes = Encoding.UTF8.GetMaxByteCount(str.Length);
+            var ptr = Marshal.AllocHGlobal(maxBytes + 1);
 
-        [SecuritySafeCritical]
-        private void Free(IntPtr ptr)
-        {
-            Marshal.FreeHGlobal(ptr);
+            var dest = new Span<byte>((void*)ptr, maxBytes + 1);
+            int written = Encoding.UTF8.GetBytes(str, dest);
+            dest[written] = 0;
+
+            ms_finalizers.Enqueue(ptr);
+            *(IntPtr*)(&cxt->result[8]) = ptr;
         }
 
         [SecuritySafeCritical]
@@ -448,22 +437,14 @@ namespace CounterStrikeSharp.API.Core
         {
             if (type == typeof(string))
             {
-                var nativeUtf8 = *(IntPtr*)&ptr[0];
+                var nativeUtf8 = *(byte**)ptr;
 
-                if (nativeUtf8 == IntPtr.Zero)
+                if (nativeUtf8 == null)
                 {
                     return null;
                 }
 
-                var len = 0;
-                while (Marshal.ReadByte(nativeUtf8, len) != 0)
-                {
-                    ++len;
-                }
-
-                var buffer = new byte[len];
-                Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
-                return Encoding.UTF8.GetString(buffer);
+                return Marshal.PtrToStringUTF8((IntPtr)nativeUtf8);
             }
 
             if (typeof(NativeObject).IsAssignableFrom(type))
@@ -487,14 +468,7 @@ namespace CounterStrikeSharp.API.Core
 
             if (type == typeof(object))
             {
-                // var dataPtr = *(IntPtr*)&ptr[0];
-                // var dataLength = *(long*)&ptr[8];
-                //
-                // byte[] data = new byte[dataLength];
-                // Marshal.Copy(dataPtr, data, 0, (int)dataLength);
-
                 return null;
-                //return MsgPackDeserializer.Deserialize(data);
             }
 
             if (type.IsEnum)
@@ -515,6 +489,22 @@ namespace CounterStrikeSharp.API.Core
         {
             var obj = Marshal.PtrToStructure(new IntPtr(ptr), type);
             return obj;
+        }
+
+        [SecurityCritical]
+        internal unsafe string GetResultString()
+        {
+            fixed (fxScriptContext* cxt = &m_extContext)
+            {
+                var nativeUtf8 = *(byte**)(&cxt->result[0]);
+
+                if (nativeUtf8 == null)
+                {
+                    return null;
+                }
+
+                return Marshal.PtrToStringUTF8((IntPtr)nativeUtf8);
+            }
         }
 
         /// <summary>
@@ -578,9 +568,9 @@ namespace CounterStrikeSharp.API.Core
         {
             lock (ms_lock)
             {
-                while (ms_finalizers.TryDequeue(out var cb))
+                while (ms_finalizers.TryDequeue(out var ptr))
                 {
-                    cb();
+                    Marshal.FreeHGlobal(ptr);
                 }
             }
         }

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -510,6 +510,19 @@ namespace CounterStrikeSharp.API.Core
 			return obj;
 		}
 
+		/// <summary>
+		/// Reads a primitive/unmanaged result directly from the context's result
+		/// buffer without Marshal.PtrToStructure or boxing overhead.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public unsafe T GetResultPrimitive<T>() where T : unmanaged
+		{
+			fixed (fxScriptContext* cxt = &m_extContext)
+			{
+				return *(T*)(&cxt->result[0]);
+			}
+		}
+
 
 		[SecurityCritical]
 		internal unsafe string ErrorHandler(byte* error)

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
@@ -282,6 +283,21 @@ namespace CounterStrikeSharp.API.Core
 		{
 			*(long*)(&cxt->functionData[8 * cxt->numArguments]) = 0;
 			Marshal.StructureToPtr(arg, new IntPtr(cxt->functionData + (8 * cxt->numArguments)), true);
+		}
+
+		/// <summary>
+		/// Pushes a primitive/unmanaged value directly into the context's function
+		/// data buffer without boxing or Marshal.StructureToPtr overhead.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public unsafe void PushPrimitive<T>(T value) where T : unmanaged
+		{
+			fixed (fxScriptContext* cxt = &m_extContext)
+			{
+				*(long*)(&cxt->functionData[8 * cxt->numArguments]) = 0;
+				*(T*)(&cxt->functionData[8 * cxt->numArguments]) = value;
+				cxt->numArguments++;
+			}
 		}
 
 		[SecurityCritical]

--- a/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
+++ b/managed/CounterStrikeSharp.API/Core/ScriptContext.cs
@@ -93,6 +93,7 @@ namespace CounterStrikeSharp.API.Core
 			InternalReset();
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[SecurityCritical]
 		private void InternalReset()
 		{
@@ -169,6 +170,7 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		[SecurityCritical]
 		public unsafe void SetIdentifier(ulong arg)
 		{
@@ -178,17 +180,21 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public unsafe void CheckErrors()
 		{
-			fixed (fxScriptContext* context = &m_extContext)
+			if (m_extContext.hasError != 0)
 			{
-				if (Convert.ToBoolean(context->hasError))
-				{
-					string error = GetResult<string>();
-					Reset();
-					throw new NativeException(error);
-				}
+				ThrowNativeError();
 			}
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void ThrowNativeError()
+		{
+			string error = GetResult<string>();
+			Reset();
+			throw new NativeException(error);
 		}
 
 		[SecurityCritical]
@@ -543,7 +549,17 @@ namespace CounterStrikeSharp.API.Core
 			return "Native invocation failed.";
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal void GlobalCleanUp()
+		{
+			if (!ms_finalizers.IsEmpty)
+			{
+				GlobalCleanUpSlow();
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void GlobalCleanUpSlow()
 		{
 			lock (ms_lock)
 			{

--- a/managed/CounterStrikeSharp.API/CounterStrikeSharp.API.csproj
+++ b/managed/CounterStrikeSharp.API/CounterStrikeSharp.API.csproj
@@ -24,8 +24,8 @@
         <ApiCompatContractAssembly>.\ApiCompat\v202.dll</ApiCompatContractAssembly>
     </PropertyGroup>
     <ItemGroup>
-        <None Remove="Modules\Commands\CommandInfo"/>
-        <None Remove="Modules\Disabled\**"/>
+        <None Remove="Modules\Commands\CommandInfo" />
+        <None Remove="Modules\Disabled\**" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
@@ -33,31 +33,32 @@
         </AssemblyAttribute>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0"/>
-        <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" Version="8.0.203"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.3"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
-        <PackageReference Include="Scrutor" Version="4.2.2"/>
-        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0"/>
-        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0"/>
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0"/>
-        <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
-        <PackageReference Include="Tomlyn" Version="0.19.0"/>
+        <PackageReference Include="FastGenericNew" Version="3.3.1" />
+        <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="Microsoft.DotNet.ApiCompat.Task" Version="8.0.203" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Scrutor" Version="4.2.2" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+        <PackageReference Include="Tomlyn" Version="0.19.0" />
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Generated\Schema\" />
-        <Folder Include="Modules\Errors"/>
+        <Folder Include="Modules\Errors" />
     </ItemGroup>
     <ItemGroup>
-        <Compile Remove="Modules\Disabled\**"/>
+        <Compile Remove="Modules\Disabled\**" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Remove="Modules\Disabled\**"/>
+        <EmbeddedResource Remove="Modules\Disabled\**" />
     </ItemGroup>
-    <PropertyGroup/>
+    <PropertyGroup />
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
@@ -65,12 +66,8 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation">
-        <Exec
-            Command="git describe --long --always --exclude=* --abbrev=7"
-            ConsoleToMSBuild="True"
-            IgnoreExitCode="False"
-        >
-            <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput"/>
+        <Exec Command="git describe --long --always --exclude=* --abbrev=7" ConsoleToMSBuild="True" IgnoreExitCode="False">
+            <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput" />
         </Exec>
     </Target>
 

--- a/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
@@ -16,7 +16,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8E7D0305);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -28,7 +28,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x47C507A2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -88,7 +88,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAD28109C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -133,7 +133,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x886D0EB6);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (CommandCallingContext)ScriptContext.GlobalScriptContext.GetResult(typeof(CommandCallingContext));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<CommandCallingContext>();
 			}
 		}
 
@@ -166,7 +166,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x52254718);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -235,7 +235,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x94829E2B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (ulong)ScriptContext.GlobalScriptContext.GetResult(typeof(ulong));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<ulong>();
 			}
 		}
 
@@ -246,7 +246,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB6E0E54C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (short)ScriptContext.GlobalScriptContext.GetResult(typeof(short));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<short>();
 			}
 		}
 
@@ -279,7 +279,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x6288420D);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (ushort)ScriptContext.GlobalScriptContext.GetResult(typeof(ushort));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<ushort>();
 			}
 		}
 
@@ -312,7 +312,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xECC4CC16);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -353,7 +353,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF22079B9);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (ushort)ScriptContext.GlobalScriptContext.GetResult(typeof(ushort));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<ushort>();
 			}
 		}
 
@@ -385,7 +385,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7AC3DA1C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (uint)ScriptContext.GlobalScriptContext.GetResult(typeof(uint));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<uint>();
 			}
 		}
 
@@ -396,7 +396,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x78156617);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -407,7 +407,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7AC49FA2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (uint)ScriptContext.GlobalScriptContext.GetResult(typeof(uint));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<uint>();
 			}
 		}
 
@@ -418,7 +418,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD20595B4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -440,7 +440,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7ABC76EA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -576,7 +576,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD88A5CD5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -586,7 +586,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x970CB1B9);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -596,7 +596,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xFDF24F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -606,7 +606,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAB744EC5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -616,7 +616,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x39A17C88);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (double)ScriptContext.GlobalScriptContext.GetResult(typeof(double));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<double>();
 			}
 		}
 
@@ -626,7 +626,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5DF2E20D);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -636,7 +636,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x97E331CA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -678,7 +678,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x758F3FD2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -689,7 +689,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD4372AF3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -700,7 +700,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x20BB05CE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -713,7 +713,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7A3E109A);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -727,7 +727,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7A3E1099);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -751,7 +751,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xC3572E09);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -761,7 +761,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x881F122B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -793,7 +793,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x95B04711);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -803,7 +803,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x84108452);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (double)ScriptContext.GlobalScriptContext.GetResult(typeof(double));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<double>();
 			}
 		}
 
@@ -826,7 +826,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFAED2BE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -883,7 +883,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD551EB1F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -894,7 +894,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x83542138);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -916,7 +916,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEE3A8DEF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -927,7 +927,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAF13DA94);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (uint)ScriptContext.GlobalScriptContext.GetResult(typeof(uint));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<uint>();
 			}
 		}
 
@@ -938,7 +938,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDBC17174);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -948,7 +948,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5756DB36);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -959,7 +959,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x6E38A1FC);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -980,7 +980,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x3E50DC41);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -991,7 +991,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD1F30B3B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (ulong)ScriptContext.GlobalScriptContext.GetResult(typeof(ulong));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<ulong>();
 			}
 		}
 
@@ -1074,7 +1074,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x43C4A2B3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (uint)ScriptContext.GlobalScriptContext.GetResult(typeof(uint));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<uint>();
 			}
 		}
 
@@ -1095,7 +1095,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x445FE212);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1146,7 +1146,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD3E04DA0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -1182,7 +1182,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7B472432);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1237,7 +1237,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFFEE451);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -1249,7 +1249,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB17427CC);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -1261,7 +1261,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDF96CB6F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -1333,7 +1333,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xED480293);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -1345,7 +1345,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x88E33F2F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1393,7 +1393,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x80D3545B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1405,7 +1405,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA5EADD5B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (ulong)ScriptContext.GlobalScriptContext.GetResult(typeof(ulong));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<ulong>();
 			}
 		}
 
@@ -1435,7 +1435,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2531DA2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1454,7 +1454,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8D25187D);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1473,7 +1473,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF873189F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1491,7 +1491,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE9D17E63);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1543,7 +1543,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE9E1819B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1555,7 +1555,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEA506CFF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1566,7 +1566,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA585F34E);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -1578,7 +1578,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x67A31E3F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1599,7 +1599,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x61521EF3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1611,7 +1611,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x57B77D8F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (short)ScriptContext.GlobalScriptContext.GetResult(typeof(short));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<short>();
 			}
 		}
 
@@ -1623,7 +1623,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xFE413B0C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -1662,7 +1662,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x9CE4FC56);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -1698,7 +1698,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x981E9B5B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1708,7 +1708,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB216AAAC);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -1721,7 +1721,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7A5BAE39);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -1767,7 +1767,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xC971FB70);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -1780,7 +1780,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5FA8BDC9);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -1793,7 +1793,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xECCF528B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (long)ScriptContext.GlobalScriptContext.GetResult(typeof(long));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<long>();
 			}
 		}
 
@@ -1806,7 +1806,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xED208CEA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -1819,7 +1819,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x54C0D7F4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -1847,7 +1847,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xECD23703);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -1860,7 +1860,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF74C465F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -1872,7 +1872,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDE4E1549);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -2058,7 +2058,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x70CDDEBE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (ulong)ScriptContext.GlobalScriptContext.GetResult(typeof(ulong));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<ulong>();
 			}
 		}
 
@@ -2080,7 +2080,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x22CD6C9F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -2091,7 +2091,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE8E83344);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2102,7 +2102,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xBC758632);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2133,7 +2133,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xC17BA71B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (int)ScriptContext.GlobalScriptContext.GetResult(typeof(int));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
 			}
 		}
 
@@ -2165,7 +2165,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA67981DF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2175,7 +2175,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2CD71169);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2185,7 +2185,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x16585EAF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2195,7 +2195,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA2E1A42);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2205,7 +2205,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD27D7946);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2215,7 +2215,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x11907167);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (IntPtr)ScriptContext.GlobalScriptContext.GetResult(typeof(IntPtr));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
 			}
 		}
 
@@ -2226,7 +2226,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2A85CBB2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -2237,7 +2237,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2A85CBB3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -2248,7 +2248,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2A85CBB0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -2317,7 +2317,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x94B5BA5F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -2328,7 +2328,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xBAC81CD6);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -2339,7 +2339,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x13CB3150);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -2350,7 +2350,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEAF6FE79);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (float)ScriptContext.GlobalScriptContext.GetResult(typeof(float));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<float>();
 			}
 		}
 
@@ -2361,7 +2361,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA4B37BC4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (bool)ScriptContext.GlobalScriptContext.GetResult(typeof(bool));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
 			}
 		}
 
@@ -2385,7 +2385,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE95644E3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (ListenOverride)ScriptContext.GlobalScriptContext.GetResult(typeof(ListenOverride));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<ListenOverride>();
 			}
 		}
 
@@ -2407,7 +2407,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x9685205C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (uint)ScriptContext.GlobalScriptContext.GetResult(typeof(uint));
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<uint>();
 			}
 		}
     }

--- a/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
@@ -11,7 +11,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool AddListener(string name, InputArgument callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8E7D0305);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -23,7 +23,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool RemoveListener(string name, InputArgument callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x47C507A2);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -35,8 +35,8 @@ namespace CounterStrikeSharp.API.Core
         public static void AddCommand(string name, string description, bool serveronly, int flags, InputArgument callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(description);
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.PushString(description);
 			ScriptContext.GlobalScriptContext.PushPrimitive(serveronly);
 			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
@@ -49,7 +49,7 @@ namespace CounterStrikeSharp.API.Core
         public static void RemoveCommand(string name, InputArgument callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEC2412DB);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -60,7 +60,7 @@ namespace CounterStrikeSharp.API.Core
         public static void AddCommandListener(string cmd, InputArgument callback, bool post){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(cmd);
+			ScriptContext.GlobalScriptContext.PushString(cmd);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.PushPrimitive(post);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2D2D803D);
@@ -72,7 +72,7 @@ namespace CounterStrikeSharp.API.Core
         public static void RemoveCommandListener(string cmd, InputArgument callback, bool post){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(cmd);
+			ScriptContext.GlobalScriptContext.PushString(cmd);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.PushPrimitive(post);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x34DBBF1A);
@@ -99,7 +99,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2E52E8EA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -110,7 +110,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8FABC059);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -122,7 +122,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x3E8D9805);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -141,7 +141,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
-			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.PushString(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xCA5BA982);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -152,7 +152,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
-			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.PushString(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x85376751);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -162,7 +162,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr FindConvar(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x52254718);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -174,7 +174,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x9A736FC1);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -185,11 +185,11 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(clientindex);
-			ScriptContext.GlobalScriptContext.Push(convarname);
+			ScriptContext.GlobalScriptContext.PushString(convarname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAE4B1B79);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -197,8 +197,8 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(clientindex);
-			ScriptContext.GlobalScriptContext.Push(convarname);
-			ScriptContext.GlobalScriptContext.Push(convarvalue);
+			ScriptContext.GlobalScriptContext.PushString(convarname);
+			ScriptContext.GlobalScriptContext.PushString(convarvalue);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4C61E8BB);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -209,8 +209,8 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(clientslot);
-			ScriptContext.GlobalScriptContext.Push(convarname);
-			ScriptContext.GlobalScriptContext.Push(convarvalue);
+			ScriptContext.GlobalScriptContext.PushString(convarname);
+			ScriptContext.GlobalScriptContext.PushString(convarvalue);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xC8728BEC);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -257,7 +257,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB6F0E2F3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -268,14 +268,14 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x341D1F67);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
         public static ushort GetConvarAccessIndexByName(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x6288420D);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -301,7 +301,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5CC184F8);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -320,7 +320,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5EF52D6C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -341,9 +341,9 @@ namespace CounterStrikeSharp.API.Core
         public static ushort CreateConvar<T>(string name, short type, string helptext, ulong flags, bool hasmin, bool hasmax, T defaultvalue, T minvalue, T maxvalue){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(type);
-			ScriptContext.GlobalScriptContext.Push(helptext);
+			ScriptContext.GlobalScriptContext.PushString(helptext);
 			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
 			ScriptContext.GlobalScriptContext.PushPrimitive(hasmin);
 			ScriptContext.GlobalScriptContext.PushPrimitive(hasmax);
@@ -374,7 +374,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x600A804B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -429,7 +429,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x41C49F71);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -481,7 +481,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2450A3E5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -555,7 +555,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x43C2ED68);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -565,14 +565,14 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD8F03FD4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
         public static bool IsMapValid(string mapname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(mapname);
+			ScriptContext.GlobalScriptContext.PushString(mapname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD88A5CD5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -643,7 +643,7 @@ namespace CounterStrikeSharp.API.Core
         public static void IssueServerCommand(string command){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.PushString(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA5901A5E);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -653,7 +653,7 @@ namespace CounterStrikeSharp.API.Core
         public static void PrecacheModel(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x77A0C6BE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -663,7 +663,7 @@ namespace CounterStrikeSharp.API.Core
         public static void AddResource(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x3B1DC491);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -673,7 +673,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool PrecacheSound(string name, bool preload){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(preload);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x758F3FD2);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -685,7 +685,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool IsSoundPrecached(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD4372AF3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -696,7 +696,7 @@ namespace CounterStrikeSharp.API.Core
         public static float GetSoundDuration(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x20BB05CE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -822,7 +822,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(interfacetype);
-			ScriptContext.GlobalScriptContext.Push(interfacename);
+			ScriptContext.GlobalScriptContext.PushString(interfacename);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFAED2BE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -833,7 +833,7 @@ namespace CounterStrikeSharp.API.Core
         public static T GetCommandParamValue<T>(string param, DataType datatype, T defaultvalue){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(param);
+			ScriptContext.GlobalScriptContext.PushString(param);
 			ScriptContext.GlobalScriptContext.PushPrimitive(datatype);
 			ScriptContext.GlobalScriptContext.Push(defaultvalue);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x748F302F);
@@ -846,7 +846,7 @@ namespace CounterStrikeSharp.API.Core
         public static void PrintToServerConsole(string msg){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(msg);
+			ScriptContext.GlobalScriptContext.PushString(msg);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5D4EE1C2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -869,7 +869,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
 			ScriptContext.GlobalScriptContext.PushPrimitive(huddestination);
-			ScriptContext.GlobalScriptContext.Push(msg);
+			ScriptContext.GlobalScriptContext.PushString(msg);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8F03FA72);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -905,7 +905,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x28DCCD51);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -967,7 +967,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
-			ScriptContext.GlobalScriptContext.Push(message);
+			ScriptContext.GlobalScriptContext.PushString(message);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7F033898);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1002,15 +1002,15 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x46A45CB0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
         public static void HookEntityOutput(string classname, string outputname, InputArgument callback, HookMode mode){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(classname);
-			ScriptContext.GlobalScriptContext.Push(outputname);
+			ScriptContext.GlobalScriptContext.PushString(classname);
+			ScriptContext.GlobalScriptContext.PushString(outputname);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.PushPrimitive(mode);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x15245242);
@@ -1022,8 +1022,8 @@ namespace CounterStrikeSharp.API.Core
         public static void UnhookEntityOutput(string classname, string outputname, InputArgument callback, HookMode mode){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(classname);
-			ScriptContext.GlobalScriptContext.Push(outputname);
+			ScriptContext.GlobalScriptContext.PushString(classname);
+			ScriptContext.GlobalScriptContext.PushString(outputname);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.PushPrimitive(mode);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x87DBD139);
@@ -1036,10 +1036,10 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(pthis);
-			ScriptContext.GlobalScriptContext.Push(inputname);
+			ScriptContext.GlobalScriptContext.PushString(inputname);
 			ScriptContext.GlobalScriptContext.PushPrimitive(activator);
 			ScriptContext.GlobalScriptContext.PushPrimitive(caller);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.PushPrimitive(outputid);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x259E084C);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1051,10 +1051,10 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(ptarget);
-			ScriptContext.GlobalScriptContext.Push(inputname);
+			ScriptContext.GlobalScriptContext.PushString(inputname);
 			ScriptContext.GlobalScriptContext.PushPrimitive(activator);
 			ScriptContext.GlobalScriptContext.PushPrimitive(caller);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.PushPrimitive(delay);
 			ScriptContext.GlobalScriptContext.PushPrimitive(outputid);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4CFDE98A);
@@ -1068,7 +1068,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(filtermask);
 			ScriptContext.GlobalScriptContext.PushPrimitive(ent);
-			ScriptContext.GlobalScriptContext.Push(sound);
+			ScriptContext.GlobalScriptContext.PushString(sound);
 			ScriptContext.GlobalScriptContext.PushPrimitive(volume);
 			ScriptContext.GlobalScriptContext.PushPrimitive(pitch);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x43C4A2B3);
@@ -1113,7 +1113,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
-			ScriptContext.GlobalScriptContext.Push(key);
+			ScriptContext.GlobalScriptContext.PushString(key);
 			ScriptContext.GlobalScriptContext.PushPrimitive(type);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA9A569AC);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1126,7 +1126,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
-			ScriptContext.GlobalScriptContext.Push(key);
+			ScriptContext.GlobalScriptContext.PushString(key);
 			ScriptContext.GlobalScriptContext.PushPrimitive(type);
 			foreach (var obj in arguments)
 			{
@@ -1142,7 +1142,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
-			ScriptContext.GlobalScriptContext.Push(key);
+			ScriptContext.GlobalScriptContext.PushString(key);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD3E04DA0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1153,7 +1153,7 @@ namespace CounterStrikeSharp.API.Core
         public static void HookEvent(string name, InputArgument callback, bool ispost){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.PushPrimitive(ispost);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE71F04D5);
@@ -1165,7 +1165,7 @@ namespace CounterStrikeSharp.API.Core
         public static void UnhookEvent(string name, InputArgument callback, bool ispost){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.PushPrimitive(ispost);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2154AFAE);
@@ -1177,7 +1177,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateEvent(string name, bool force){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(force);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7B472432);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1225,7 +1225,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFF86998);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -1233,7 +1233,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFFEE451);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1245,7 +1245,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB17427CC);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1257,7 +1257,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDF96CB6F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1269,11 +1269,11 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB4EBC50A);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -1281,7 +1281,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x31859DC5);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1293,7 +1293,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x627CF47B);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1305,8 +1305,8 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xCB7E7B9E);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1317,7 +1317,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4F1363D8);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1328,7 +1328,7 @@ namespace CounterStrikeSharp.API.Core
         public static int LoadEventsFromFile(string path, bool searchall){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(path);
+			ScriptContext.GlobalScriptContext.PushString(path);
 			ScriptContext.GlobalScriptContext.PushPrimitive(searchall);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xED480293);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1341,7 +1341,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x88E33F2F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1353,7 +1353,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE8A2033B);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1365,7 +1365,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAB420F50);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1377,7 +1377,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAF9B1691);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1389,7 +1389,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x80D3545B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1401,7 +1401,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA5EADD5B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1413,7 +1413,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD0C2D3CF);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1443,8 +1443,8 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(pointer);
-			ScriptContext.GlobalScriptContext.Push(binaryname);
-			ScriptContext.GlobalScriptContext.Push(signature);
+			ScriptContext.GlobalScriptContext.PushString(binaryname);
+			ScriptContext.GlobalScriptContext.PushString(signature);
 			ScriptContext.GlobalScriptContext.PushPrimitive(numarguments);
 			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
 			foreach (var obj in arguments)
@@ -1461,8 +1461,8 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateVirtualFunctionBySymbol(string binaryname, string symbolname, int vtableoffset, int numarguments, int returntype, object[] arguments){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(binaryname);
-			ScriptContext.GlobalScriptContext.Push(symbolname);
+			ScriptContext.GlobalScriptContext.PushString(binaryname);
+			ScriptContext.GlobalScriptContext.PushString(symbolname);
 			ScriptContext.GlobalScriptContext.PushPrimitive(vtableoffset);
 			ScriptContext.GlobalScriptContext.PushPrimitive(numarguments);
 			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
@@ -1538,8 +1538,8 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr FindSignature(string modulepath, string signature){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(modulepath);
-			ScriptContext.GlobalScriptContext.Push(signature);
+			ScriptContext.GlobalScriptContext.PushString(modulepath);
+			ScriptContext.GlobalScriptContext.PushString(signature);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE9E1819B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1550,8 +1550,8 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr FindVirtualTable(string modulepath, string vtablename){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(modulepath);
-			ScriptContext.GlobalScriptContext.Push(vtablename);
+			ScriptContext.GlobalScriptContext.PushString(modulepath);
+			ScriptContext.GlobalScriptContext.PushString(vtablename);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEA506CFF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1595,7 +1595,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr MetaFactory(string interfacename){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(interfacename);
+			ScriptContext.GlobalScriptContext.PushString(interfacename);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x61521EF3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1606,8 +1606,8 @@ namespace CounterStrikeSharp.API.Core
         public static short GetSchemaOffset(string classname, string propname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(classname);
-			ScriptContext.GlobalScriptContext.Push(propname);
+			ScriptContext.GlobalScriptContext.PushString(classname);
+			ScriptContext.GlobalScriptContext.PushString(propname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x57B77D8F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1618,8 +1618,8 @@ namespace CounterStrikeSharp.API.Core
         public static bool IsSchemaFieldNetworked(string classname, string propname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(classname);
-			ScriptContext.GlobalScriptContext.Push(propname);
+			ScriptContext.GlobalScriptContext.PushString(classname);
+			ScriptContext.GlobalScriptContext.PushString(propname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xFE413B0C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1632,8 +1632,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(instance);
 			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
-			ScriptContext.GlobalScriptContext.Push(classname);
-			ScriptContext.GlobalScriptContext.Push(propname);
+			ScriptContext.GlobalScriptContext.PushString(classname);
+			ScriptContext.GlobalScriptContext.PushString(propname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD01E4EB5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1646,8 +1646,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.PushPrimitive(instance);
 			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
-			ScriptContext.GlobalScriptContext.Push(classname);
-			ScriptContext.GlobalScriptContext.Push(propname);
+			ScriptContext.GlobalScriptContext.PushString(classname);
+			ScriptContext.GlobalScriptContext.PushString(propname);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAB9AA921);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1658,7 +1658,7 @@ namespace CounterStrikeSharp.API.Core
         public static int GetSchemaClassSize(string classname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(classname);
+			ScriptContext.GlobalScriptContext.PushString(classname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x9CE4FC56);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1763,7 +1763,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xC971FB70);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1775,7 +1775,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5FA8BDC9);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1788,7 +1788,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xECCF528B);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1801,7 +1801,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xED208CEA);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1814,7 +1814,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x54C0D7F4);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1827,12 +1827,12 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x66CACEEF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -1840,7 +1840,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(buffer);
 			ScriptContext.GlobalScriptContext.PushPrimitive(size);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
@@ -1855,7 +1855,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF74C465F);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1868,7 +1868,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDE4E1549);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1880,7 +1880,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x99BBC059);
@@ -1893,7 +1893,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF7AD351B);
@@ -1906,7 +1906,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF7FDEB7A);
@@ -1919,7 +1919,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD1342864);
@@ -1932,8 +1932,8 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x15C78B7F);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1945,7 +1945,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(buffer);
 			ScriptContext.GlobalScriptContext.PushPrimitive(size);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
@@ -1959,7 +1959,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x66CD6A1A);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1971,7 +1971,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4FD05AD8);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1983,7 +1983,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5117B239);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1995,7 +1995,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x40827C47);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -2007,8 +2007,8 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.PushString(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8DFD739C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2019,7 +2019,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(buffer);
 			ScriptContext.GlobalScriptContext.PushPrimitive(size);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x50DB8210);
@@ -2032,7 +2032,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x1721FCB1);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -2047,7 +2047,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x913FB7BA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -2076,7 +2076,7 @@ namespace CounterStrikeSharp.API.Core
         public static int UsermessageFindmessageidbyname(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x22CD6C9F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2087,7 +2087,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr UsermessageCreate(string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(name);
+			ScriptContext.GlobalScriptContext.PushString(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE8E83344);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2144,7 +2144,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEFE0FD1);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 
@@ -2155,7 +2155,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEF4842E);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
-			return (string)ScriptContext.GlobalScriptContext.GetResult(typeof(string));
+			return ScriptContext.GlobalScriptContext.GetResultString();
 			}
 		}
 

--- a/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
@@ -37,8 +37,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.Push(description);
-			ScriptContext.GlobalScriptContext.Push(serveronly);
-			ScriptContext.GlobalScriptContext.Push(flags);
+			ScriptContext.GlobalScriptContext.PushPrimitive(serveronly);
+			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x807C6B9C);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -62,7 +62,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(cmd);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(post);
+			ScriptContext.GlobalScriptContext.PushPrimitive(post);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2D2D803D);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -74,7 +74,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(cmd);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(post);
+			ScriptContext.GlobalScriptContext.PushPrimitive(post);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x34DBBF1A);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -84,7 +84,7 @@ namespace CounterStrikeSharp.API.Core
         public static int CommandGetArgCount(IntPtr command){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.PushPrimitive(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAD28109C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -95,7 +95,7 @@ namespace CounterStrikeSharp.API.Core
         public static string CommandGetArgString(IntPtr command){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.PushPrimitive(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2E52E8EA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -106,7 +106,7 @@ namespace CounterStrikeSharp.API.Core
         public static string CommandGetCommandString(IntPtr command){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.PushPrimitive(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8FABC059);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -117,8 +117,8 @@ namespace CounterStrikeSharp.API.Core
         public static string CommandGetArgByIndex(IntPtr command, int index){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(command);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(command);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x3E8D9805);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -129,7 +129,7 @@ namespace CounterStrikeSharp.API.Core
         public static CommandCallingContext CommandGetCallingContext(IntPtr command){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(command);
+			ScriptContext.GlobalScriptContext.PushPrimitive(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x886D0EB6);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -140,7 +140,7 @@ namespace CounterStrikeSharp.API.Core
         public static void IssueClientCommand(int slot, string command){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(slot);
+			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
 			ScriptContext.GlobalScriptContext.Push(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xCA5BA982);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -151,7 +151,7 @@ namespace CounterStrikeSharp.API.Core
         public static void IssueClientCommandFromServer(int slot, string command){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(slot);
+			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
 			ScriptContext.GlobalScriptContext.Push(command);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x85376751);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -173,7 +173,7 @@ namespace CounterStrikeSharp.API.Core
         public static void SetConvarStringValue(IntPtr convar, string value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x9A736FC1);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -184,7 +184,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetClientConvarValue(int clientindex, string convarname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(clientindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(clientindex);
 			ScriptContext.GlobalScriptContext.Push(convarname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAE4B1B79);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -196,7 +196,7 @@ namespace CounterStrikeSharp.API.Core
         public static void SetFakeClientConvarValue(int clientindex, string convarname, string convarvalue){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(clientindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(clientindex);
 			ScriptContext.GlobalScriptContext.Push(convarname);
 			ScriptContext.GlobalScriptContext.Push(convarvalue);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4C61E8BB);
@@ -208,7 +208,7 @@ namespace CounterStrikeSharp.API.Core
         public static void ReplicateConvar(int clientslot, string convarname, string convarvalue){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(clientslot);
+			ScriptContext.GlobalScriptContext.PushPrimitive(clientslot);
 			ScriptContext.GlobalScriptContext.Push(convarname);
 			ScriptContext.GlobalScriptContext.Push(convarvalue);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xC8728BEC);
@@ -220,8 +220,8 @@ namespace CounterStrikeSharp.API.Core
         public static void SetConvarFlags(ushort convar, ulong flags){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
-			ScriptContext.GlobalScriptContext.Push(flags);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB2BDCCBF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -231,7 +231,7 @@ namespace CounterStrikeSharp.API.Core
         public static ulong GetConvarFlags(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x94829E2B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -242,7 +242,7 @@ namespace CounterStrikeSharp.API.Core
         public static short GetConvarType(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB6E0E54C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -253,7 +253,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetConvarName(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB6F0E2F3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -264,7 +264,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetConvarHelpText(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x341D1F67);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -286,7 +286,7 @@ namespace CounterStrikeSharp.API.Core
         public static T GetConvarValue<T>(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x935B2E9F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -297,7 +297,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetConvarValueAsString(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5CC184F8);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -308,7 +308,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetConvarValueAddress(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xECC4CC16);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -319,7 +319,7 @@ namespace CounterStrikeSharp.API.Core
         public static void SetConvarValueAsString(ushort convar, string value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5EF52D6C);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -330,7 +330,7 @@ namespace CounterStrikeSharp.API.Core
         public static void SetConvarValue<T>(ushort convar, T value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB3DDAA0B);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -342,11 +342,11 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(type);
+			ScriptContext.GlobalScriptContext.PushPrimitive(type);
 			ScriptContext.GlobalScriptContext.Push(helptext);
-			ScriptContext.GlobalScriptContext.Push(flags);
-			ScriptContext.GlobalScriptContext.Push(hasmin);
-			ScriptContext.GlobalScriptContext.Push(hasmax);
+			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
+			ScriptContext.GlobalScriptContext.PushPrimitive(hasmin);
+			ScriptContext.GlobalScriptContext.PushPrimitive(hasmax);
 			ScriptContext.GlobalScriptContext.Push(defaultvalue);
 			ScriptContext.GlobalScriptContext.Push(minvalue);
 			ScriptContext.GlobalScriptContext.Push(maxvalue);
@@ -360,7 +360,7 @@ namespace CounterStrikeSharp.API.Core
         public static void DeleteConvar(ushort convar){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(convar);
+			ScriptContext.GlobalScriptContext.PushPrimitive(convar);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xFC28F444);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -370,7 +370,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetStringFromSymbolLarge(IntPtr pointer){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pointer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pointer);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x600A804B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -381,7 +381,7 @@ namespace CounterStrikeSharp.API.Core
         public static uint GetVariantType(IntPtr pvariant){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7AC3DA1C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -392,7 +392,7 @@ namespace CounterStrikeSharp.API.Core
         public static int GetVariantInt(IntPtr pvariant){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x78156617);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -403,7 +403,7 @@ namespace CounterStrikeSharp.API.Core
         public static uint GetVariantUint(IntPtr pvariant){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7AC49FA2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -414,7 +414,7 @@ namespace CounterStrikeSharp.API.Core
         public static float GetVariantFloat(IntPtr pvariant){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD20595B4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -425,7 +425,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetVariantString(IntPtr pvariant){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x41C49F71);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -436,7 +436,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool GetVariantBool(IntPtr pvariant){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7ABC76EA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -447,8 +447,8 @@ namespace CounterStrikeSharp.API.Core
         public static void SetVariantInt(IntPtr pvariant, int value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x801EC403);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -458,8 +458,8 @@ namespace CounterStrikeSharp.API.Core
         public static void SetVariantUint(IntPtr pvariant, uint value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x83EC7436);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -469,8 +469,8 @@ namespace CounterStrikeSharp.API.Core
         public static void SetVariantFloat(IntPtr pvariant, float value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x266E8A0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -480,7 +480,7 @@ namespace CounterStrikeSharp.API.Core
         public static void SetVariantString(IntPtr pvariant, string value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2450A3E5);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -491,8 +491,8 @@ namespace CounterStrikeSharp.API.Core
         public static void SetVariantBool(IntPtr pvariant, bool value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pvariant);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pvariant);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x83F1967E);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -502,8 +502,8 @@ namespace CounterStrikeSharp.API.Core
         public static T DynamicHookGetReturn<T>(IntPtr hook, int datatype){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(hook);
-			ScriptContext.GlobalScriptContext.Push(datatype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(hook);
+			ScriptContext.GlobalScriptContext.PushPrimitive(datatype);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4F5B80D0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -514,8 +514,8 @@ namespace CounterStrikeSharp.API.Core
         public static void DynamicHookSetReturn<T>(IntPtr hook, int datatype, T value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(hook);
-			ScriptContext.GlobalScriptContext.Push(datatype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(hook);
+			ScriptContext.GlobalScriptContext.PushPrimitive(datatype);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDB297E44);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -526,9 +526,9 @@ namespace CounterStrikeSharp.API.Core
         public static T DynamicHookGetParam<T>(IntPtr hook, int datatype, int paramindex){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(hook);
-			ScriptContext.GlobalScriptContext.Push(datatype);
-			ScriptContext.GlobalScriptContext.Push(paramindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(hook);
+			ScriptContext.GlobalScriptContext.PushPrimitive(datatype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(paramindex);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5F5ABDD5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -539,9 +539,9 @@ namespace CounterStrikeSharp.API.Core
         public static void DynamicHookSetParam<T>(IntPtr hook, int datatype, int paramindex, T value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(hook);
-			ScriptContext.GlobalScriptContext.Push(datatype);
-			ScriptContext.GlobalScriptContext.Push(paramindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(hook);
+			ScriptContext.GlobalScriptContext.PushPrimitive(datatype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(paramindex);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA96CFBC1);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -674,7 +674,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(preload);
+			ScriptContext.GlobalScriptContext.PushPrimitive(preload);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x758F3FD2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -707,9 +707,9 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateRay1(int rayType, IntPtr vec1, IntPtr vec2){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(rayType);
-			ScriptContext.GlobalScriptContext.Push(vec1);
-			ScriptContext.GlobalScriptContext.Push(vec2);
+			ScriptContext.GlobalScriptContext.PushPrimitive(rayType);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec1);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec2);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7A3E109A);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -720,10 +720,10 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateRay2(IntPtr vec1, IntPtr vec2, IntPtr vec3, IntPtr vec4){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vec1);
-			ScriptContext.GlobalScriptContext.Push(vec2);
-			ScriptContext.GlobalScriptContext.Push(vec3);
-			ScriptContext.GlobalScriptContext.Push(vec4);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec1);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec2);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec3);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec4);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7A3E1099);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -734,10 +734,10 @@ namespace CounterStrikeSharp.API.Core
         public static void TraceRay(IntPtr ray, IntPtr ptrace, IntPtr traceFilter, uint flags){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(ray);
-			ScriptContext.GlobalScriptContext.Push(ptrace);
-			ScriptContext.GlobalScriptContext.Push(traceFilter);
-			ScriptContext.GlobalScriptContext.Push(flags);
+			ScriptContext.GlobalScriptContext.PushPrimitive(ray);
+			ScriptContext.GlobalScriptContext.PushPrimitive(ptrace);
+			ScriptContext.GlobalScriptContext.PushPrimitive(traceFilter);
+			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x35182751);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -747,7 +747,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr NewSimpleTraceFilter(int indexToIgnore){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(indexToIgnore);
+			ScriptContext.GlobalScriptContext.PushPrimitive(indexToIgnore);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xC3572E09);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -768,8 +768,8 @@ namespace CounterStrikeSharp.API.Core
         public static void TraceFilterProxySetTraceTypeCallback(IntPtr traceFilter, IntPtr callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(traceFilter);
-			ScriptContext.GlobalScriptContext.Push(callback);
+			ScriptContext.GlobalScriptContext.PushPrimitive(traceFilter);
+			ScriptContext.GlobalScriptContext.PushPrimitive(callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE907BCBA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -779,8 +779,8 @@ namespace CounterStrikeSharp.API.Core
         public static void TraceFilterProxySetShouldHitEntityCallback(IntPtr traceFilter, IntPtr callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(traceFilter);
-			ScriptContext.GlobalScriptContext.Push(callback);
+			ScriptContext.GlobalScriptContext.PushPrimitive(traceFilter);
+			ScriptContext.GlobalScriptContext.PushPrimitive(callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x3858171B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -810,7 +810,7 @@ namespace CounterStrikeSharp.API.Core
         public static void QueueTaskForFrame(int tick, InputArgument callback){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(tick);
+			ScriptContext.GlobalScriptContext.PushPrimitive(tick);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2F92C340);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -821,7 +821,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetValveInterface(int interfacetype, string interfacename){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(interfacetype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(interfacetype);
 			ScriptContext.GlobalScriptContext.Push(interfacename);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFAED2BE);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -834,7 +834,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(param);
-			ScriptContext.GlobalScriptContext.Push(datatype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(datatype);
 			ScriptContext.GlobalScriptContext.Push(defaultvalue);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x748F302F);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -856,8 +856,8 @@ namespace CounterStrikeSharp.API.Core
         public static void DisconnectClient(int slot, int reason){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(slot);
-			ScriptContext.GlobalScriptContext.Push(reason);
+			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
+			ScriptContext.GlobalScriptContext.PushPrimitive(reason);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x799EE9C3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -867,8 +867,8 @@ namespace CounterStrikeSharp.API.Core
         public static void ClientPrint(int slot, int huddestination, string msg){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(slot);
-			ScriptContext.GlobalScriptContext.Push(huddestination);
+			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
+			ScriptContext.GlobalScriptContext.PushPrimitive(huddestination);
 			ScriptContext.GlobalScriptContext.Push(msg);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x8F03FA72);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -879,7 +879,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetEntityFromIndex(int index){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD551EB1F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -890,7 +890,7 @@ namespace CounterStrikeSharp.API.Core
         public static int GetUseridFromIndex(int index){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x83542138);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -901,7 +901,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetDesignerName(IntPtr pointer){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pointer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pointer);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x28DCCD51);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -912,7 +912,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetEntityPointerFromHandle(IntPtr entityhandlepointer){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(entityhandlepointer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(entityhandlepointer);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEE3A8DEF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -923,7 +923,7 @@ namespace CounterStrikeSharp.API.Core
         public static uint GetRefFromEntityPointer(IntPtr entitypointer){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(entitypointer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(entitypointer);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAF13DA94);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -934,7 +934,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetEntityPointerFromRef(uint entityref){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(entityref);
+			ScriptContext.GlobalScriptContext.PushPrimitive(entityref);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDBC17174);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -955,7 +955,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool IsRefValidEntity(uint entityref){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(entityref);
+			ScriptContext.GlobalScriptContext.PushPrimitive(entityref);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x6E38A1FC);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -966,7 +966,7 @@ namespace CounterStrikeSharp.API.Core
         public static void PrintToConsole(int index, string message){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7F033898);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -987,7 +987,7 @@ namespace CounterStrikeSharp.API.Core
         public static ulong GetPlayerAuthorizedSteamid(int slot){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(slot);
+			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD1F30B3B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -998,7 +998,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetPlayerIpAddress(int slot){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(slot);
+			ScriptContext.GlobalScriptContext.PushPrimitive(slot);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x46A45CB0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1012,7 +1012,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Push(classname);
 			ScriptContext.GlobalScriptContext.Push(outputname);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(mode);
+			ScriptContext.GlobalScriptContext.PushPrimitive(mode);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x15245242);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1025,7 +1025,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Push(classname);
 			ScriptContext.GlobalScriptContext.Push(outputname);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(mode);
+			ScriptContext.GlobalScriptContext.PushPrimitive(mode);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x87DBD139);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1035,12 +1035,12 @@ namespace CounterStrikeSharp.API.Core
         public static void AcceptInput(IntPtr pthis, string inputname, IntPtr activator, IntPtr caller, string value, int outputid){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pthis);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pthis);
 			ScriptContext.GlobalScriptContext.Push(inputname);
-			ScriptContext.GlobalScriptContext.Push(activator);
-			ScriptContext.GlobalScriptContext.Push(caller);
+			ScriptContext.GlobalScriptContext.PushPrimitive(activator);
+			ScriptContext.GlobalScriptContext.PushPrimitive(caller);
 			ScriptContext.GlobalScriptContext.Push(value);
-			ScriptContext.GlobalScriptContext.Push(outputid);
+			ScriptContext.GlobalScriptContext.PushPrimitive(outputid);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x259E084C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1050,13 +1050,13 @@ namespace CounterStrikeSharp.API.Core
         public static void AddEntityIoEvent(IntPtr ptarget, string inputname, IntPtr activator, IntPtr caller, string value, float delay, int outputid){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(ptarget);
+			ScriptContext.GlobalScriptContext.PushPrimitive(ptarget);
 			ScriptContext.GlobalScriptContext.Push(inputname);
-			ScriptContext.GlobalScriptContext.Push(activator);
-			ScriptContext.GlobalScriptContext.Push(caller);
+			ScriptContext.GlobalScriptContext.PushPrimitive(activator);
+			ScriptContext.GlobalScriptContext.PushPrimitive(caller);
 			ScriptContext.GlobalScriptContext.Push(value);
-			ScriptContext.GlobalScriptContext.Push(delay);
-			ScriptContext.GlobalScriptContext.Push(outputid);
+			ScriptContext.GlobalScriptContext.PushPrimitive(delay);
+			ScriptContext.GlobalScriptContext.PushPrimitive(outputid);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4CFDE98A);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1066,11 +1066,11 @@ namespace CounterStrikeSharp.API.Core
         public static uint EmitSoundFilter(ulong filtermask, uint ent, string sound, float volume, float pitch){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(filtermask);
-			ScriptContext.GlobalScriptContext.Push(ent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(filtermask);
+			ScriptContext.GlobalScriptContext.PushPrimitive(ent);
 			ScriptContext.GlobalScriptContext.Push(sound);
-			ScriptContext.GlobalScriptContext.Push(volume);
-			ScriptContext.GlobalScriptContext.Push(pitch);
+			ScriptContext.GlobalScriptContext.PushPrimitive(volume);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pitch);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x43C4A2B3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1081,8 +1081,8 @@ namespace CounterStrikeSharp.API.Core
         public static void DispatchSpawn(IntPtr entity, IntPtr keyvalues){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(entity);
-			ScriptContext.GlobalScriptContext.Push(keyvalues);
+			ScriptContext.GlobalScriptContext.PushPrimitive(entity);
+			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAE01E931);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1102,7 +1102,7 @@ namespace CounterStrikeSharp.API.Core
         public static void EntityKeyValuesRelease(IntPtr keyvalues){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(keyvalues);
+			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAE679E87);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1112,9 +1112,9 @@ namespace CounterStrikeSharp.API.Core
         public static T EntityKeyValuesGetValue<T>(IntPtr keyvalues, string key, uint type){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(keyvalues);
+			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
 			ScriptContext.GlobalScriptContext.Push(key);
-			ScriptContext.GlobalScriptContext.Push(type);
+			ScriptContext.GlobalScriptContext.PushPrimitive(type);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA9A569AC);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1125,9 +1125,9 @@ namespace CounterStrikeSharp.API.Core
         public static void EntityKeyValuesSetValue(IntPtr keyvalues, string key, uint type, object[] arguments){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(keyvalues);
+			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
 			ScriptContext.GlobalScriptContext.Push(key);
-			ScriptContext.GlobalScriptContext.Push(type);
+			ScriptContext.GlobalScriptContext.PushPrimitive(type);
 			foreach (var obj in arguments)
 			{
 				ScriptContext.GlobalScriptContext.Push(obj);
@@ -1141,7 +1141,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool EntityKeyValuesHasValue(IntPtr keyvalues, string key){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(keyvalues);
+			ScriptContext.GlobalScriptContext.PushPrimitive(keyvalues);
 			ScriptContext.GlobalScriptContext.Push(key);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD3E04DA0);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1155,7 +1155,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(ispost);
+			ScriptContext.GlobalScriptContext.PushPrimitive(ispost);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE71F04D5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1167,7 +1167,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(ispost);
+			ScriptContext.GlobalScriptContext.PushPrimitive(ispost);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2154AFAE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1178,7 +1178,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(force);
+			ScriptContext.GlobalScriptContext.PushPrimitive(force);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7B472432);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1189,7 +1189,7 @@ namespace CounterStrikeSharp.API.Core
         public static void FreeEvent(IntPtr gameevent){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7E8B60C2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1199,8 +1199,8 @@ namespace CounterStrikeSharp.API.Core
         public static void FireEvent(IntPtr gameevent, bool dontbroadcast){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
-			ScriptContext.GlobalScriptContext.Push(dontbroadcast);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(dontbroadcast);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2D52AEE);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1210,8 +1210,8 @@ namespace CounterStrikeSharp.API.Core
         public static void FireEventToClient(IntPtr gameevent, int clientindex){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
-			ScriptContext.GlobalScriptContext.Push(clientindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(clientindex);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x40B7C06C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1221,7 +1221,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetEventName(IntPtr gameevent){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFF86998);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1232,7 +1232,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool GetEventBool(IntPtr gameevent, string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDFFEE451);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1244,7 +1244,7 @@ namespace CounterStrikeSharp.API.Core
         public static int GetEventInt(IntPtr gameevent, string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB17427CC);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1256,7 +1256,7 @@ namespace CounterStrikeSharp.API.Core
         public static float GetEventFloat(IntPtr gameevent, string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xDF96CB6F);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1268,7 +1268,7 @@ namespace CounterStrikeSharp.API.Core
         public static string GetEventString(IntPtr gameevent, string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB4EBC50A);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1280,9 +1280,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventBool(IntPtr gameevent, string name, bool value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x31859DC5);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1292,9 +1292,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventFloat(IntPtr gameevent, string name, float value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x627CF47B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1304,7 +1304,7 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventString(IntPtr gameevent, string name, string value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.Push(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xCB7E7B9E);
@@ -1316,9 +1316,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventInt(IntPtr gameevent, string name, int value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4F1363D8);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1329,7 +1329,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(path);
-			ScriptContext.GlobalScriptContext.Push(searchall);
+			ScriptContext.GlobalScriptContext.PushPrimitive(searchall);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xED480293);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1340,7 +1340,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetEventPlayerController(IntPtr gameevent, string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x88E33F2F);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1352,9 +1352,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventPlayerController(IntPtr gameevent, string name, IntPtr value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE8A2033B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1364,9 +1364,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventEntity(IntPtr gameevent, string name, IntPtr value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAB420F50);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1376,9 +1376,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventEntityIndex(IntPtr gameevent, string name, int value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xAF9B1691);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1388,7 +1388,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetEventPlayerPawn(IntPtr gameevent, string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x80D3545B);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1400,7 +1400,7 @@ namespace CounterStrikeSharp.API.Core
         public static ulong GetEventUint64(IntPtr gameevent, string name){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA5EADD5B);
 			ScriptContext.GlobalScriptContext.Invoke();
@@ -1412,9 +1412,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetEventUint64(IntPtr gameevent, string name, ulong value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(gameevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(gameevent);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD0C2D3CF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1424,10 +1424,10 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateVirtualFunction(IntPtr pointer, int vtableoffset, int numarguments, int returntype, object[] arguments){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pointer);
-			ScriptContext.GlobalScriptContext.Push(vtableoffset);
-			ScriptContext.GlobalScriptContext.Push(numarguments);
-			ScriptContext.GlobalScriptContext.Push(returntype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pointer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vtableoffset);
+			ScriptContext.GlobalScriptContext.PushPrimitive(numarguments);
+			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
 			foreach (var obj in arguments)
 			{
 				ScriptContext.GlobalScriptContext.Push(obj);
@@ -1442,11 +1442,11 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateVirtualFunctionBySignature(IntPtr pointer, string binaryname, string signature, int numarguments, int returntype, object[] arguments){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pointer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pointer);
 			ScriptContext.GlobalScriptContext.Push(binaryname);
 			ScriptContext.GlobalScriptContext.Push(signature);
-			ScriptContext.GlobalScriptContext.Push(numarguments);
-			ScriptContext.GlobalScriptContext.Push(returntype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(numarguments);
+			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
 			foreach (var obj in arguments)
 			{
 				ScriptContext.GlobalScriptContext.Push(obj);
@@ -1463,9 +1463,9 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(binaryname);
 			ScriptContext.GlobalScriptContext.Push(symbolname);
-			ScriptContext.GlobalScriptContext.Push(vtableoffset);
-			ScriptContext.GlobalScriptContext.Push(numarguments);
-			ScriptContext.GlobalScriptContext.Push(returntype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vtableoffset);
+			ScriptContext.GlobalScriptContext.PushPrimitive(numarguments);
+			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
 			foreach (var obj in arguments)
 			{
 				ScriptContext.GlobalScriptContext.Push(obj);
@@ -1480,10 +1480,10 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateVirtualFunctionFromVTable(IntPtr pointer, int vtableoffset, int numarguments, int returntype, object[] arguments){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(pointer);
-			ScriptContext.GlobalScriptContext.Push(vtableoffset);
-			ScriptContext.GlobalScriptContext.Push(numarguments);
-			ScriptContext.GlobalScriptContext.Push(returntype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pointer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vtableoffset);
+			ScriptContext.GlobalScriptContext.PushPrimitive(numarguments);
+			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
 			foreach (var obj in arguments)
 			{
 				ScriptContext.GlobalScriptContext.Push(obj);
@@ -1498,9 +1498,9 @@ namespace CounterStrikeSharp.API.Core
         public static void HookFunction(IntPtr function, InputArgument hook, bool post){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(function);
+			ScriptContext.GlobalScriptContext.PushPrimitive(function);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)hook);
-			ScriptContext.GlobalScriptContext.Push(post);
+			ScriptContext.GlobalScriptContext.PushPrimitive(post);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA6C8BA9B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1510,9 +1510,9 @@ namespace CounterStrikeSharp.API.Core
         public static void UnhookFunction(IntPtr function, InputArgument hook, bool post){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(function);
+			ScriptContext.GlobalScriptContext.PushPrimitive(function);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)hook);
-			ScriptContext.GlobalScriptContext.Push(post);
+			ScriptContext.GlobalScriptContext.PushPrimitive(post);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2051B00);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1522,8 +1522,8 @@ namespace CounterStrikeSharp.API.Core
         public static T ExecuteVirtualFunction<T>(IntPtr function, bool bypass, object[] arguments){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(function);
-			ScriptContext.GlobalScriptContext.Push(bypass);
+			ScriptContext.GlobalScriptContext.PushPrimitive(function);
+			ScriptContext.GlobalScriptContext.PushPrimitive(bypass);
 			foreach (var obj in arguments)
 			{
 				ScriptContext.GlobalScriptContext.Push(obj);
@@ -1562,7 +1562,7 @@ namespace CounterStrikeSharp.API.Core
         public static int GetNetworkVectorSize(IntPtr vec){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vec);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA585F34E);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1573,8 +1573,8 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr GetNetworkVectorElementAt(IntPtr vec, int index){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vec);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x67A31E3F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1585,7 +1585,7 @@ namespace CounterStrikeSharp.API.Core
         public static void RemoveAllNetworkVectorElements(IntPtr vec){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vec);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vec);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x67206C08);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1630,8 +1630,8 @@ namespace CounterStrikeSharp.API.Core
         public static T GetSchemaValueByName<T>(IntPtr instance, int returntype, string classname, string propname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(instance);
-			ScriptContext.GlobalScriptContext.Push(returntype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(instance);
+			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
 			ScriptContext.GlobalScriptContext.Push(classname);
 			ScriptContext.GlobalScriptContext.Push(propname);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD01E4EB5);
@@ -1644,8 +1644,8 @@ namespace CounterStrikeSharp.API.Core
         public static void SetSchemaValueByName<T>(IntPtr instance, int returntype, string classname, string propname, T value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(instance);
-			ScriptContext.GlobalScriptContext.Push(returntype);
+			ScriptContext.GlobalScriptContext.PushPrimitive(instance);
+			ScriptContext.GlobalScriptContext.PushPrimitive(returntype);
 			ScriptContext.GlobalScriptContext.Push(classname);
 			ScriptContext.GlobalScriptContext.Push(propname);
 			ScriptContext.GlobalScriptContext.Push(value);
@@ -1669,10 +1669,10 @@ namespace CounterStrikeSharp.API.Core
         public static void SchemaSetStateChanged(IntPtr instance, uint offset, uint arrayindex, uint pathindex){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(instance);
-			ScriptContext.GlobalScriptContext.Push(offset);
-			ScriptContext.GlobalScriptContext.Push(arrayindex);
-			ScriptContext.GlobalScriptContext.Push(pathindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(instance);
+			ScriptContext.GlobalScriptContext.PushPrimitive(offset);
+			ScriptContext.GlobalScriptContext.PushPrimitive(arrayindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pathindex);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7D697B7C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1682,10 +1682,10 @@ namespace CounterStrikeSharp.API.Core
         public static void SchemaNetworkStateChanged(IntPtr instance, uint offset, uint arrayindex, uint pathindex){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(instance);
-			ScriptContext.GlobalScriptContext.Push(offset);
-			ScriptContext.GlobalScriptContext.Push(arrayindex);
-			ScriptContext.GlobalScriptContext.Push(pathindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(instance);
+			ScriptContext.GlobalScriptContext.PushPrimitive(offset);
+			ScriptContext.GlobalScriptContext.PushPrimitive(arrayindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pathindex);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xBBE9D700);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1715,9 +1715,9 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr CreateTimer(float interval, InputArgument callback, int flags){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(interval);
+			ScriptContext.GlobalScriptContext.PushPrimitive(interval);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(flags);
+			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x7A5BAE39);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1728,7 +1728,7 @@ namespace CounterStrikeSharp.API.Core
         public static void KillTimer(IntPtr timer){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(timer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(timer);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x32313EDF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1738,9 +1738,9 @@ namespace CounterStrikeSharp.API.Core
         public static void HookUsermessage(int messageid, InputArgument callback, HookMode mode){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(messageid);
+			ScriptContext.GlobalScriptContext.PushPrimitive(messageid);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(mode);
+			ScriptContext.GlobalScriptContext.PushPrimitive(mode);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x76C63A83);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1750,9 +1750,9 @@ namespace CounterStrikeSharp.API.Core
         public static void UnhookUsermessage(int messageid, InputArgument callback, HookMode mode){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(messageid);
+			ScriptContext.GlobalScriptContext.PushPrimitive(messageid);
 			ScriptContext.GlobalScriptContext.Push((InputArgument)callback);
-			ScriptContext.GlobalScriptContext.Push(mode);
+			ScriptContext.GlobalScriptContext.PushPrimitive(mode);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x63B0AC38);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1776,7 +1776,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5FA8BDC9);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1789,7 +1789,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xECCF528B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1802,7 +1802,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xED208CEA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1815,7 +1815,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x54C0D7F4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1828,7 +1828,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x66CACEEF);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1841,9 +1841,9 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(buffer);
-			ScriptContext.GlobalScriptContext.Push(size);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(buffer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(size);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xECD23703);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1856,7 +1856,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF74C465F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1881,8 +1881,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x99BBC059);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1894,8 +1894,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF7AD351B);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1907,8 +1907,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF7FDEB7A);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1920,8 +1920,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD1342864);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1934,7 +1934,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
 			ScriptContext.GlobalScriptContext.Push(value);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x15C78B7F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1946,9 +1946,9 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(buffer);
-			ScriptContext.GlobalScriptContext.Push(size);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(buffer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(size);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF7C09993);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1960,19 +1960,19 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x66CD6A1A);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
 			}
 		}
 
-        public static void PbAddint64(UserMessage message, string name, object value){
+        public static void PbAddint64(UserMessage message, string name, long value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x4FD05AD8);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1984,7 +1984,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x5117B239);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -1996,7 +1996,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x40827C47);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2020,8 +2020,8 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(buffer);
-			ScriptContext.GlobalScriptContext.Push(size);
+			ScriptContext.GlobalScriptContext.PushPrimitive(buffer);
+			ScriptContext.GlobalScriptContext.PushPrimitive(size);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x50DB8210);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2033,7 +2033,7 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
 			ScriptContext.GlobalScriptContext.Push(name);
-			ScriptContext.GlobalScriptContext.Push(index);
+			ScriptContext.GlobalScriptContext.PushPrimitive(index);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x1721FCB1);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2066,7 +2066,7 @@ namespace CounterStrikeSharp.API.Core
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
 			ScriptContext.GlobalScriptContext.Push(message);
-			ScriptContext.GlobalScriptContext.Push(recipients);
+			ScriptContext.GlobalScriptContext.PushPrimitive(recipients);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xB4ED43AA);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2098,7 +2098,7 @@ namespace CounterStrikeSharp.API.Core
         public static IntPtr UsermessageCreatebyid(int id){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(id);
+			ScriptContext.GlobalScriptContext.PushPrimitive(id);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xBC758632);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2222,7 +2222,7 @@ namespace CounterStrikeSharp.API.Core
         public static float VectorGetX(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2A85CBB2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2233,7 +2233,7 @@ namespace CounterStrikeSharp.API.Core
         public static float VectorGetY(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2A85CBB3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2244,7 +2244,7 @@ namespace CounterStrikeSharp.API.Core
         public static float VectorGetZ(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2A85CBB0);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2255,8 +2255,8 @@ namespace CounterStrikeSharp.API.Core
         public static void VectorSetX(IntPtr vector, float value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2B62AFA6);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2266,8 +2266,8 @@ namespace CounterStrikeSharp.API.Core
         public static void VectorSetY(IntPtr vector, float value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2B62AFA7);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2277,8 +2277,8 @@ namespace CounterStrikeSharp.API.Core
         public static void VectorSetZ(IntPtr vector, float value){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
-			ScriptContext.GlobalScriptContext.Push(value);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x2B62AFA4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2288,9 +2288,9 @@ namespace CounterStrikeSharp.API.Core
         public static void VectorAngles(IntPtr vector, IntPtr pseudoup, IntPtr outangle){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
-			ScriptContext.GlobalScriptContext.Push(pseudoup);
-			ScriptContext.GlobalScriptContext.Push(outangle);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(pseudoup);
+			ScriptContext.GlobalScriptContext.PushPrimitive(outangle);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x6E6886B1);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2300,10 +2300,10 @@ namespace CounterStrikeSharp.API.Core
         public static void AngleVectors(IntPtr vector, IntPtr forwardout, IntPtr rightout, IntPtr upout){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
-			ScriptContext.GlobalScriptContext.Push(forwardout);
-			ScriptContext.GlobalScriptContext.Push(rightout);
-			ScriptContext.GlobalScriptContext.Push(upout);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(forwardout);
+			ScriptContext.GlobalScriptContext.PushPrimitive(rightout);
+			ScriptContext.GlobalScriptContext.PushPrimitive(upout);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xF696A2F1);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2313,7 +2313,7 @@ namespace CounterStrikeSharp.API.Core
         public static float VectorLength(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x94B5BA5F);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2324,7 +2324,7 @@ namespace CounterStrikeSharp.API.Core
         public static float VectorLength2d(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xBAC81CD6);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2335,7 +2335,7 @@ namespace CounterStrikeSharp.API.Core
         public static float VectorLengthSqr(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x13CB3150);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2346,7 +2346,7 @@ namespace CounterStrikeSharp.API.Core
         public static float VectorLength2dSqr(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xEAF6FE79);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2357,7 +2357,7 @@ namespace CounterStrikeSharp.API.Core
         public static bool VectorIsZero(IntPtr vector){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(vector);
+			ScriptContext.GlobalScriptContext.PushPrimitive(vector);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xA4B37BC4);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2368,9 +2368,9 @@ namespace CounterStrikeSharp.API.Core
         public static void SetClientListening(IntPtr receiver, IntPtr sender, uint listen){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(receiver);
-			ScriptContext.GlobalScriptContext.Push(sender);
-			ScriptContext.GlobalScriptContext.Push(listen);
+			ScriptContext.GlobalScriptContext.PushPrimitive(receiver);
+			ScriptContext.GlobalScriptContext.PushPrimitive(sender);
+			ScriptContext.GlobalScriptContext.PushPrimitive(listen);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xD38BEE77);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2380,8 +2380,8 @@ namespace CounterStrikeSharp.API.Core
         public static ListenOverride GetClientListening(IntPtr receiver, IntPtr sender){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(receiver);
-			ScriptContext.GlobalScriptContext.Push(sender);
+			ScriptContext.GlobalScriptContext.PushPrimitive(receiver);
+			ScriptContext.GlobalScriptContext.PushPrimitive(sender);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xE95644E3);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2392,8 +2392,8 @@ namespace CounterStrikeSharp.API.Core
         public static void SetClientVoiceFlags(IntPtr client, uint flags){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(client);
-			ScriptContext.GlobalScriptContext.Push(flags);
+			ScriptContext.GlobalScriptContext.PushPrimitive(client);
+			ScriptContext.GlobalScriptContext.PushPrimitive(flags);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x48EB2FC8);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
@@ -2403,7 +2403,7 @@ namespace CounterStrikeSharp.API.Core
         public static uint GetClientVoiceFlags(IntPtr client){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.Push(client);
+			ScriptContext.GlobalScriptContext.PushPrimitive(client);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0x9685205C);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();

--- a/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using CounterStrikeSharp.API.Core;
+using FastGenericNew;
 
 namespace CounterStrikeSharp.API.Modules.Memory;
 
@@ -102,7 +103,7 @@ public class Schema
     {
         if (pointer == IntPtr.Zero) throw new ArgumentNullException(nameof(pointer), "Schema target points to null.");
 
-        return (T)Activator.CreateInstance(typeof(T), pointer + GetSchemaOffset(className, memberName));
+        return FastNew.CreateInstance<T, IntPtr>(pointer + GetSchemaOffset(className, memberName));
     }
 
     public static unsafe ref T GetRef<T>(IntPtr pointer, string className, string memberName)
@@ -120,7 +121,7 @@ public class Schema
             return default;
         }
 
-        return (T)Activator.CreateInstance(typeof(T), pointerTo);
+        return FastNew.CreateInstance<T, IntPtr>(pointerTo);
     }
 
     public static T GetPointer<T>(IntPtr pointer, string className, string memberName)
@@ -133,7 +134,7 @@ public class Schema
             return default;
         }
 
-        return (T)Activator.CreateInstance(typeof(T), pointerTo);
+        return FastNew.CreateInstance<T, IntPtr>(pointerTo);
     }
 
     public static unsafe Span<T> GetFixedArray<T>(IntPtr pointer, string className, string memberName, int count)

--- a/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Memory/Schema.cs
@@ -11,7 +11,9 @@ namespace CounterStrikeSharp.API.Modules.Memory;
 
 public class Schema
 {
-    private static Dictionary<Tuple<string, string>, short> _schemaOffsets = new();
+    record SchemaKey(string ClassName, string PropertyName);
+
+    private static Dictionary<SchemaKey, short> _schemaOffsets = new();
 
     private static HashSet<string> _cs2BadList = new HashSet<string>()
     {
@@ -52,7 +54,7 @@ public class Schema
         "m_nActiveCoinRank",
         "m_nMusicID",
     };
-    
+
     public static int GetClassSize(string className) => NativeAPI.GetSchemaClassSize(className);
 
     public static short GetSchemaOffset(string className, string propertyName)
@@ -62,7 +64,7 @@ public class Schema
             throw new Exception($"Cannot set or get '{className}::{propertyName}' with \"FollowCS2ServerGuidelines\" option enabled.");
         }
 
-        var key = new Tuple<string, string>(className, propertyName);
+        var key = new SchemaKey(className, propertyName);
         if (!_schemaOffsets.TryGetValue(key, out var offset))
         {
             offset = NativeAPI.GetSchemaOffset(className, propertyName);
@@ -71,7 +73,7 @@ public class Schema
 
         return offset;
     }
-    
+
     public static bool IsSchemaFieldNetworked(string className, string propertyName)
     {
         return NativeAPI.IsSchemaFieldNetworked(className, propertyName);
@@ -151,7 +153,7 @@ public class Schema
     {
         return GetSchemaValue<string>(pointer, className, memberName);
     }
-    
+
     /// <summary>
     /// Reads a UTF8 encoded string from the specified pointer, class name, and member name.
     /// These are for networked strings, which need to be read differently.
@@ -164,32 +166,32 @@ public class Schema
     {
         return Utilities.ReadStringUtf8(pointer + GetSchemaOffset(className, memberName));
     }
-    
+
     // Used to write to `string_t` and `char*` pointer type strings
     public unsafe static void SetString(IntPtr pointer, string className, string memberName, string value)
     {
         SetSchemaValue(pointer, className, memberName, value);
     }
-    
+
     // Used to write to the char[] specified at the schema location, i.e. char m_iszPlayerName[128]; 
     internal unsafe static void SetStringBytes(IntPtr pointer, string className, string memberName, string value, int maxLength)
     {
         var handle = GetSchemaValue<IntPtr>(pointer, className, memberName);
-        
+
         var bytes = Encoding.UTF8.GetBytes(value);
         if (bytes.Length > maxLength)
         {
             throw new ArgumentException($"String length exceeds maximum length of {maxLength}");
         }
-        
+
         for (int i = 0; i < bytes.Length; i++)
         {
             Unsafe.Write((void*)(handle.ToInt64() + i), bytes[i]);
         }
-        
+
         Unsafe.Write((void*)(handle.ToInt64() + bytes.Length), 0);
     }
-    
+
     public static T GetCustomMarshalledType<T>(IntPtr pointer, string className, string memberName)
     {
         var type = typeof(T);
@@ -201,7 +203,7 @@ public class Schema
 
         return (T)result;
     }
-    
+
     public static void SetCustomMarshalledType<T>(IntPtr pointer, string className, string memberName, T value)
     {
         var type = typeof(T);

--- a/managed/CounterStrikeSharp.API/Modules/Utils/CHandle.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Utils/CHandle.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CounterStrikeSharp.API.Modules.Entities;
+using FastGenericNew;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CounterStrikeSharp.API.Modules.Utils;
@@ -71,7 +72,7 @@ public class CHandle<T> : IEquatable<CHandle<T>> where T : NativeEntity
         if (entity == null)
             return null;
 
-        return (T)Activator.CreateInstance(typeof(T), entity)!;
+        return FastNew.CreateInstance<T, IntPtr>(entity.Value);
     }
 
     public override string ToString() => IsValid ? $"Index = {Index}, Serial = {SerialNum}" : "<invalid>";
@@ -125,7 +126,7 @@ public class PointerTo<T> : NativeObject where T : NativeObject
         {
             unsafe
             {
-                return (T)Activator.CreateInstance(typeof(T), Unsafe.Read<IntPtr>((void*)Handle));
+                return FastNew.CreateInstance<T, IntPtr>(Unsafe.Read<IntPtr>((void*)Handle));
             }
         }
     }

--- a/managed/CounterStrikeSharp.API/Utilities.cs
+++ b/managed/CounterStrikeSharp.API/Utilities.cs
@@ -21,6 +21,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using CounterStrikeSharp.API.Modules.Commands.Targeting;
 using CounterStrikeSharp.API.Modules.Entities;
+using FastGenericNew;
 using Microsoft.Extensions.Logging;
 
 namespace CounterStrikeSharp.API
@@ -47,12 +48,12 @@ namespace CounterStrikeSharp.API
                 return null;
             }
 
-            return (T)Activator.CreateInstance(typeof(T), entityPtr)!;
+            return FastNew.CreateInstance<T, IntPtr>(entityPtr.Value);
         }
 
         public static T? CreateEntityByName<T>(string name) where T : CBaseEntity
         {
-            return (T?)Activator.CreateInstance(typeof(T), VirtualFunctions.UTIL_CreateEntityByName(name, -1));
+            return FastNew.CreateInstance<T, IntPtr>(VirtualFunctions.UTIL_CreateEntityByName(name, -1))!;
         }
 
         public static CCSPlayerController? GetPlayerFromIndex(int index)
@@ -208,7 +209,7 @@ namespace CounterStrikeSharp.API
                 return null;
             }
 
-            return (T)Activator.CreateInstance(typeof(T), pointerTo)!;
+            return FastNew.CreateInstance<T, IntPtr>(pointerTo);
         }
 
         private static int FindSchemaChain(string className) => Schema.GetSchemaOffset(className, "__m_pChainEntity");

--- a/tooling/CodeGen.Natives/Mapping.cs
+++ b/tooling/CodeGen.Natives/Mapping.cs
@@ -12,11 +12,20 @@ public class Mapping
             case "int":
             case "uint":
             case "float":
-            case "pointer":
             case "bool":
             case "double":
             case "short":
-                return "Push(";
+            case "int16":
+            case "uint16":
+            case "uint64":
+            case "long":
+            case "int64":
+            case "HookMode":
+            case "ListenOverride":
+            case "DataType_t":
+            case "CommandCallingContext":
+            case "pointer":
+                return "PushPrimitive(";
             case "func":
             case "callback":
                 return "Push((InputArgument)";
@@ -59,6 +68,7 @@ public class Mapping
             case "uint64":
                 return "ulong";
             case "long":
+            case "int64":
                 return "long";
             case "func":
             case "callback":

--- a/tooling/CodeGen.Natives/Mapping.cs
+++ b/tooling/CodeGen.Natives/Mapping.cs
@@ -30,6 +30,7 @@ public class Mapping
             case "callback":
                 return "Push((InputArgument)";
             case "charPtr":
+            case "string":
                 return "PushString(";
         }
 

--- a/tooling/CodeGen.Natives/Mapping.cs
+++ b/tooling/CodeGen.Natives/Mapping.cs
@@ -96,6 +96,36 @@ public class Mapping
         return "object";
     }
 
+    /// <summary>
+    /// Returns true if the native return type maps to an unmanaged primitive
+    /// that can use GetResultPrimitive&lt;T&gt;() instead of GetResult(typeof(T)).
+    /// </summary>
+    public static bool IsPrimitiveReturnType(string returnType)
+    {
+        switch (returnType)
+        {
+            case "int":
+            case "uint":
+            case "float":
+            case "bool":
+            case "double":
+            case "short":
+            case "int16":
+            case "uint16":
+            case "uint64":
+            case "long":
+            case "int64":
+            case "pointer":
+            case "HookMode":
+            case "ListenOverride":
+            case "DataType_t":
+            case "CommandCallingContext":
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public static string GetCSharpTypeFromGameEventType(string type)
     {
         switch (type)

--- a/tooling/CodeGen.Natives/Scripts/GenerateNatives.cs
+++ b/tooling/CodeGen.Natives/Scripts/GenerateNatives.cs
@@ -83,6 +83,11 @@ public partial class Generators
                     returnStr.Append(
                         $"\t\t\treturn ScriptContext.GlobalScriptContext.GetResultPrimitive<{Mapping.GetCSharpType(native.ReturnType)}>();\n");
                 }
+                else if (native.ReturnType == "string")
+                {
+                    returnStr.Append(
+                        $"\t\t\treturn ScriptContext.GlobalScriptContext.GetResultString();\n");
+                }
                 else
                 {
                     returnStr.Append(

--- a/tooling/CodeGen.Natives/Scripts/GenerateNatives.cs
+++ b/tooling/CodeGen.Natives/Scripts/GenerateNatives.cs
@@ -78,8 +78,16 @@ public partial class Generators
 
             if (native.ReturnType != "void")
             {
-                returnStr.Append(
-                    $"\t\t\treturn ({Mapping.GetCSharpType(native.ReturnType)})ScriptContext.GlobalScriptContext.GetResult(typeof({Mapping.GetCSharpType(native.ReturnType)}));\n");
+                if (Mapping.IsPrimitiveReturnType(native.ReturnType))
+                {
+                    returnStr.Append(
+                        $"\t\t\treturn ScriptContext.GlobalScriptContext.GetResultPrimitive<{Mapping.GetCSharpType(native.ReturnType)}>();\n");
+                }
+                else
+                {
+                    returnStr.Append(
+                        $"\t\t\treturn ({Mapping.GetCSharpType(native.ReturnType)})ScriptContext.GlobalScriptContext.GetResult(typeof({Mapping.GetCSharpType(native.ReturnType)}));\n");
+                }
             }
 
             returnStr.Append("\t\t\t}\n");


### PR DESCRIPTION
## Benchmark Diff: `perf/improvements` vs `benchmarking` baseline

**New:** `72b5491c` (2026-04-10) | **Baseline:** `ae604f16` (2026-03-23)

### Entity Lifecycle

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| Entity create+spawn info_target | 11,029 | 8,178 | -2,851 | **-25.9%** |
| GetPlayerFromSlot | 580 | 140 | -440 | **-75.9%** |

### GameEvent

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| GameEvent Fire | 4,211 | 2,683 | -1,528 | **-36.3%** |

### Mixed

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| Mixed (4 natives/iter) | 338 | 156 | -182 | **-53.8%** |

### NetMessage

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| NetMessage Send | 18,733 | 11,883 | -6,850 | **-36.6%** |

### Primitive Args

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| GetConvarFlags (ushort → ulong) | 415 | 185 | -230 | **-55.4%** |
| GetConvarType (ushort → short) | 422 | 165 | -257 | **-60.9%** |

### Primitive Return

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| GetEngineTime (double, no args) | 251 | 145 | -106 | **-42.2%** |
| GetMaxClients (int, no args) | 234 | 115 | -119 | **-50.9%** |
| GetServerCurrentTime (float, no args) | 257 | 141 | -116 | **-45.1%** |
| GetTickCount (int, no args) | 220 | 76 | -144 | **-65.5%** |
| GetTickInterval (float, no args) | 230 | 139 | -91 | **-39.6%** |
| IsServerPaused (bool, no args) | 301 | 121 | -180 | **-59.8%** |

### Schema

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| GetDeclaredClass (CBodyComponent) | 475 | 115 | -360 | **-75.8%** |
| GetSchemaValue\<int\> (Health) | 124 | 88 | -36 | **-29.0%** |
| SchemaOffset 4 keys | 103 | 63 | -40 | **-38.8%** |
| SchemaOffset cached | 99 | 61 | -38 | **-38.4%** |

### String Push

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| FindConvar (string → pointer) | 475 | 237 | -238 | **-50.1%** |
| PushString 9 bytes | 432 | 248 | -184 | **-42.6%** |
| PushString 200 bytes | 766 | 524 | -242 | **-31.6%** |
| PushString 2000 bytes | 2,601 | 2,090 | -511 | **-19.6%** |
| PushString 9000 bytes (overflow) | 9,880 | 8,347 | -1,533 | **-15.5%** |

### String Return

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| GetConvarName (ushort → string) | 409 | 208 | -201 | **-49.1%** |
| GetMapName (string, no args) | 368 | 435 | +67 | **+18.2%** |

### Virtual Function

| Benchmark | Baseline (ns) | New (ns) | Delta (ns) | Change |
|:----------|------:|------:|------:|------:|
| VFunc IsPlayerPawn (high-level API) | 2,903 | 1,781 | -1,122 | **-38.7%** |
| VFunc IsPlayerPawn (pre-created delegate) | 758 | 403 | -355 | **-46.8%** |

---