### PR TITLE
fix: update CBaseEntity_TakeDamageOld linux signature

### DIFF
--- a/configs/addons/counterstrikesharp/gamedata/gamedata.json
+++ b/configs/addons/counterstrikesharp/gamedata/gamedata.json
@@ -209,7 +209,7 @@
     "signatures": {
       "library": "server",
       "windows": "40 55 53 56 57 41 54 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4D 8B E0",
-      "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 FD 41 54 49 89 F4 53 48 89 D3 48 83 EC ? 48 85 D2"
+      "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 FD 31 FF"
     }
   },
   "CBaseTrigger_StartTouch": {


### PR DESCRIPTION
Update linux signature for CBaseEntity_TakeDamageOld to match current server binary after AG2 update.