### PR TITLE
fix: guard Hook_StartupServer against spurious second call (HLTV wakeup / ss_dead)

### DIFF
--- a/src/core/timer_system.cpp
+++ b/src/core/timer_system.cpp
@@ -88,15 +88,19 @@ void TimerSystem::OnLevelEnd()
     m_has_map_ticked = false;
 }
 
-void TimerSystem::OnStartupServer()
+void TimerSystem::OnStartupServer(bool levelShutdown)
 {
-    if (m_has_map_ticked)
+    if (levelShutdown && m_has_map_ticked)
     {
         CALL_GLOBAL_LISTENER(OnLevelEnd());
 
         CSSHARP_CORE_TRACE("name={0}", "LevelShutdown");
     }
 
+    // Reset is UNCONDITIONAL -- universal_time math in OnGameFrame depends on
+    // m_has_map_ticked being false on the first frame of every new session,
+    // whether that session came in via a genuine LevelShutdown or a workshop
+    // ss_dead reload.
     m_has_map_ticked = false;
     m_has_map_simulated = false;
 }

--- a/src/core/timer_system.h
+++ b/src/core/timer_system.h
@@ -72,7 +72,14 @@ class TimerSystem : public GlobalClass
     void OnShutdown() override;
     void OnLevelEnd() override;
     void OnGameFrame(bool simulating);
-    void OnStartupServer();
+    // levelShutdown=true on a genuine OnLevelShutdown -> OnStartupServer sequence
+    // (real changelevel/shutdown). levelShutdown=false on workshop ss_dead reload
+    // cycles that fire Hook_StartupServer without OnLevelShutdown -- in that case
+    // we must NOT fire OnLevelEnd (PlayerManager disconnects still-connected
+    // players -> stale .NET callbacks -> SEGV on the next DispatchConCommand
+    // hook), but we MUST still reset the per-map tick state for universal_time
+    // math to stay correct across the cycle.
+    void OnStartupServer(bool levelShutdown);
     double CalculateNextThink(double last_think_time, float interval);
     void RunFrame();
     void RemoveMapChangeTimers();

--- a/src/mm_plugin.cpp
+++ b/src/mm_plugin.cpp
@@ -204,12 +204,28 @@ bool CounterStrikeSharpMMPlugin::Load(PluginId id, ISmmAPI* ismm, char* error, s
     return true;
 }
 
+static bool s_bLevelShutdownOccurred = false;
+
 void CounterStrikeSharpMMPlugin::Hook_StartupServer(const GameSessionConfiguration_t& config, ISource2WorldSession*, const char*)
 {
     globals::entitySystem = interfaces::pGameResourceServiceServer->GetGameEntitySystem();
+    // Remove before adding to prevent double-registration when workshop addon changes
+    // trigger a second StartupServer within the same map session (ss_dead cycle).
+    globals::entitySystem->RemoveListenerEntity(&globals::entityManager.entityListener);
     globals::entitySystem->AddListenerEntity(&globals::entityManager.entityListener);
 
-    globals::timerSystem.OnStartupServer();
+    // Only fire OnLevelEnd lifecycle after a genuine loop-mode deactivation (OnLevelShutdown).
+    // Workshop addon changes trigger a second StartupServer via an internal ss_dead cycle
+    // without deactivating the loop mode; calling OnStartupServer here fires OnLevelEnd →
+    // PlayerManager disconnects still-connected players in CSS state → stale .NET callbacks
+    // → SEGV on the next DispatchConCommand hook.
+    // OnLevelShutdown (via ILoopMode::LoopShutdown post-hook in metamod-source) fires only
+    // on genuine changelevel/shutdown, not during the ss_dead reload cycle.
+    if (s_bLevelShutdownOccurred)
+    {
+        s_bLevelShutdownOccurred = false;
+        globals::timerSystem.OnStartupServer();
+    }
 
     on_activate_callback->ScriptContext().Reset();
     on_activate_callback->ScriptContext().Push(globals::getGlobalVars()->mapname.ToCStr());
@@ -299,7 +315,7 @@ int CounterStrikeSharpMMPlugin::Hook_LoadEventsFromFile(const char* filename, bo
     RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void CounterStrikeSharpMMPlugin::OnLevelShutdown() {}
+void CounterStrikeSharpMMPlugin::OnLevelShutdown() { s_bLevelShutdownOccurred = true; }
 
 bool CounterStrikeSharpMMPlugin::Pause(char* error, size_t maxlen) { return true; }
 

--- a/src/mm_plugin.cpp
+++ b/src/mm_plugin.cpp
@@ -214,18 +214,19 @@ void CounterStrikeSharpMMPlugin::Hook_StartupServer(const GameSessionConfigurati
     globals::entitySystem->RemoveListenerEntity(&globals::entityManager.entityListener);
     globals::entitySystem->AddListenerEntity(&globals::entityManager.entityListener);
 
-    // Only fire OnLevelEnd lifecycle after a genuine loop-mode deactivation (OnLevelShutdown).
-    // Workshop addon changes trigger a second StartupServer via an internal ss_dead cycle
-    // without deactivating the loop mode; calling OnStartupServer here fires OnLevelEnd →
-    // PlayerManager disconnects still-connected players in CSS state → stale .NET callbacks
-    // → SEGV on the next DispatchConCommand hook.
-    // OnLevelShutdown (via ILoopMode::LoopShutdown post-hook in metamod-source) fires only
-    // on genuine changelevel/shutdown, not during the ss_dead reload cycle.
-    if (s_bLevelShutdownOccurred)
-    {
-        s_bLevelShutdownOccurred = false;
-        globals::timerSystem.OnStartupServer();
-    }
+    // Workshop ss_dead reload cycles fire Hook_StartupServer without a
+    // preceding OnLevelShutdown. We pass that distinction down so that:
+    //   levelShutdown=true  -> fires OnLevelEnd (PlayerManager etc.) and
+    //                          resets timer tick state. Genuine changelevel.
+    //   levelShutdown=false -> ONLY resets timer tick state. No OnLevelEnd,
+    //                          which is what avoids the PlayerManager
+    //                          disconnect -> stale .NET callbacks -> SEGV
+    //                          chain on ss_dead reloads.
+    // Tick-state reset must be unconditional so universal_time math in
+    // OnGameFrame doesn't desync across the cycle (otherwise pending one-off
+    // timers stall arbitrarily long).
+    globals::timerSystem.OnStartupServer(s_bLevelShutdownOccurred);
+    s_bLevelShutdownOccurred = false;
 
     on_activate_callback->ScriptContext().Reset();
     on_activate_callback->ScriptContext().Push(globals::getGlobalVars()->mapname.ToCStr());


### PR DESCRIPTION
## Problem

`Hook_StartupServer` can fire twice for the same session when CS2
internally reloads without deactivating the loop mode. The second call
fires `OnLevelEnd` → PlayerManager disconnects connected players in CSS
state → stale .NET callbacks → SEGV on the next `DispatchConCommand`.

Two known triggers:

- **Workshop map load** (`host_workshop_map`) — CS2 goes through an
  internal `ss_dead` reload to fetch the addon and fires
  `Hook_StartupServer` a second time.
- **HLTV wakeup** — when the first player connects to a hibernating
  server, HLTV starts its own session and triggers a second
  `Hook_StartupServer`.

## Fix

Track whether the call follows a genuine `OnLevelShutdown` (set in the
`OnLevelShutdown` hook). `OnStartupServer` takes a `bool levelShutdown`:

- `true` → fire `OnLevelEnd` and reset per-map tick state (genuine path)
- `false` → reset tick state only, no `OnLevelEnd` (the spurious cycle)

Tick-state reset is unconditional — `OnGameFrame`'s `universal_time`
math needs it false on the first frame of every session regardless of
which path started it.

## Testing

Verified on CS2 1.41.6.2 across 40+ map transitions: `host_workshop_map`
cycles, `changelevel` with `tv_broadcast` on, HLTV wakeup from
hibernation, MatchZy loaded throughout. No crashes.

## Related

Fixes #946 and #1239.

Also resolves the following MatchZy issues (same root cause, no MatchZy changes needed):
- https://github.com/shobhit-pathak/MatchZy/issues/380
- https://github.com/shobhit-pathak/MatchZy/issues/241
- https://github.com/shobhit-pathak/MatchZy/issues/311