### PR TITLE
fix: guard silent chat trim to avoid OOB write

### DIFF
--- a/src/core/managers/chat_manager.cpp
+++ b/src/core/managers/chat_manager.cpp
@@ -70,7 +70,11 @@ void DetourHostSay(CEntityInstance* pController, CCommand& args, bool teamonly, 
         char* pszMessage = (char*)(args.ArgS() + prefix.length() + 1);
 
         // Trailing slashes are only removed if Host_Say has been called.
-        if (bSilent) pszMessage[V_strlen(pszMessage) - 1] = 0;
+        if (bSilent){
+            const auto len = V_strlen(pszMessage);
+            if (len > 0) { pszMessage[len - 1] = 0;}
+        }
+
 
         CCommand args;
         args.Tokenize(pszMessage);


### PR DESCRIPTION
### Problem
When a silent chat trigger is sent alone, `pszMessage` becomes empty (`V_strlen == 0`), leading to a potential out-of-bounds (OOB) write via `pszMessage[len - 1] = 0`.

### Solution
Added a length check inside the `bSilent` block to ensure the trailing character is only removed when `len > 0`.

### Impact & Testing
- **Risk:** Low risk; safely handles the empty message edge case.
- **Testing:** Manually tested with single-character silent triggers (`!` and `/`). Works perfectly without any issues, and normal commands continue to function as expected.