### PR TITLE
Draft: pin patched hl2sdk for CS2 2000872 native rebuild

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "libraries/hl2sdk-cs2"]
 	path = libraries/hl2sdk-cs2
-	url = https://github.com/alliedmodders/hl2sdk
-	branch = cs2
+	url = https://github.com/tomastaker/hl2sdk
+	branch = codex/cs2-2000872-metamod-css-fix
 [submodule "libraries/metamod-source"]
 	path = libraries/metamod-source
 	url = https://github.com/alliedmodders/metamod-source


### PR DESCRIPTION
Draft PR for testing the CS2 `2000872` update with the SDK changes from alliedmodders/hl2sdk#396.

I am marking this as draft because the final version should not keep pointing at my fork forever. Once alliedmodders/hl2sdk#396 is merged, this submodule should point back to `alliedmodders/hl2sdk` and the merged commit.

Why I opened this anyway: rebuilding CounterStrikeSharp `v1.0.370` against the patched SDK fixed the native load failure on my live Linux CS2 server.

Before rebuilding, the native CSS binary still referenced old symbols like:

- `g_bUpdateStringTokenDatabase`
- `RegisterStringToken`

After rebuilding against the patched SDK, those imports were gone.

What I tested:

- rebuilt CounterStrikeSharp `v1.0.370` native Linux binary against this SDK commit
- deployed it together with a Metamod build made against the same SDK
- restarted the CS2 container cleanly after deploy

What I saw after restart:

- Metamod loaded normally: `[META] Loaded 1 plugin`
- CSS started: `CounterStrikeSharp.API Loaded Successfully`
- CSS hooks were added
- my CSS plugin started and exposed its HTTP endpoint
- plugin health returned `status=ok` and `nativeAuthAvailable=true`
- server state returned `loggedOnToSteam=true`, `vacSecure=true`, `mapTimelimitMinutes=60`, `mapTimeLeftSource=mp_timelimit`

There is still a separate issue: CSS logs missing gamedata signatures for:

- `Host_Say`
- `CEntityInstance_AcceptInput`
- `CBaseEntity_TakeDamageOld`

Those did not block startup or the plugin flow I tested, but they probably still need to be updated before this is fully clean.
