### PR TITLE
perf: halve what an open center HTML menu costs per tick

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Translations/PlayerLanguageExtensions.cs
+++ b/managed/CounterStrikeSharp.API/Core/Translations/PlayerLanguageExtensions.cs
@@ -10,7 +10,11 @@ public static class PlayerLanguageExtensions
     /// </summary>
     public static CultureInfo GetLanguage(this CCSPlayerController? player)
     {
-        if (player == null || !player.IsValid) return PlayerLanguageManager.Instance.GetDefaultLanguage();
+        // Bots and HLTV have no Steam ID, and constructing a SteamID from zero throws.
+        if (player == null || !player.IsValid || player.IsBot || player.IsHLTV)
+        {
+            return PlayerLanguageManager.Instance.GetDefaultLanguage();
+        }
         
         return PlayerLanguageManager.Instance.GetLanguage((SteamID)player.SteamID);
     }

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -62,6 +62,10 @@ public class CenterHtmlMenu : BaseMenu
 public class CenterHtmlMenuInstance : BaseMenuInstance
 {
     private readonly BasePlugin _plugin;
+
+    // Display runs on every tick, so the builder is kept and cleared
+    // instead of allocating a new one each time.
+    private readonly StringBuilder _builder = new();
     public override int NumPerPage => 5; // one less than the actual number of items per page to avoid truncated options
     protected override int MenuItemsPerPage => (Menu.ExitButton ? 0 : 1) + ((HasPrevButton && HasNextButton) ? NumPerPage - 1 : NumPerPage);
 
@@ -85,7 +89,8 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
             return;
         }
 
-        var builder = new StringBuilder();
+        var builder = _builder;
+        builder.Clear();
         builder.Append($"<b><font color='{centerHtmlMenu.TitleColor}'>{centerHtmlMenu.Title}</font></b>");
         builder.AppendLine("<br>");
 

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -66,6 +66,7 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
     // Display runs on every tick, so the builder is kept and cleared
     // instead of allocating a new one each time.
     private readonly StringBuilder _builder = new();
+    private Core.EventShowSurvivalRespawnStatus? _panelEvent;
     public override int NumPerPage => 5; // one less than the actual number of items per page to avoid truncated options
     protected override int MenuItemsPerPage => (Menu.ExitButton ? 0 : 1) + ((HasPrevButton && HasNextButton) ? NumPerPage - 1 : NumPerPage);
 
@@ -122,14 +123,28 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
             builder.AppendLine("<br>");
         }
 
-        var currentPageText = builder.ToString();
-        Player.PrintToCenterHtml(currentPageText);
+        SendPanel(builder.ToString());
+    }
+
+    // The panel has to be resent on every tick to stay on screen, so building
+    // and freeing a game event each time is most of what an open menu costs.
+    // The event is kept for as long as the menu is open and refilled instead.
+    private void SendPanel(string text)
+    {
+        Guard.IsValidEntity(Player);
+
+        _panelEvent ??= new Core.EventShowSurvivalRespawnStatus(true) { Userid = Player, Duration = 5 };
+        _panelEvent.LocToken = text;
+        _panelEvent.FireEventToClient(Player);
     }
 
     public override void Close()
     {
         base.Close();
         RemoveOnTickListener();
+
+        _panelEvent?.Free();
+        _panelEvent = null;
 
         // Send a blank message to clear the menu
         Player.PrintToCenterHtml(" ");

--- a/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Menu/CenterHtmlMenu.cs
@@ -14,6 +14,7 @@
  *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
  */
 
+using System.Globalization;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
@@ -67,6 +68,13 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
     // instead of allocating a new one each time.
     private readonly StringBuilder _builder = new();
     private Core.EventShowSurvivalRespawnStatus? _panelEvent;
+
+    // Display runs on every tick and each label goes through the localization stack,
+    // so they are read once per language rather than once per tick.
+    private CultureInfo? _labelLanguage;
+    private string _previousLabel = string.Empty;
+    private string _nextLabel = string.Empty;
+    private string _closeLabel = string.Empty;
     public override int NumPerPage => 5; // one less than the actual number of items per page to avoid truncated options
     protected override int MenuItemsPerPage => (Menu.ExitButton ? 0 : 1) + ((HasPrevButton && HasNextButton) ? NumPerPage - 1 : NumPerPage);
 
@@ -90,6 +98,8 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
             return;
         }
 
+        RefreshLabels();
+
         var builder = _builder;
         builder.Clear();
         builder.Append($"<b><font color='{centerHtmlMenu.TitleColor}'>{centerHtmlMenu.Title}</font></b>");
@@ -107,23 +117,38 @@ public class CenterHtmlMenuInstance : BaseMenuInstance
 
         if (HasPrevButton)
         {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.PrevPageColor}'>!7</font> &#60;- {Application.Localizer["menu.button.previous"]}");
+            builder.AppendFormat($"<font color='{centerHtmlMenu.PrevPageColor}'>!7</font> &#60;- {_previousLabel}");
             builder.AppendLine("<br>");
         }
 
         if (HasNextButton)
         {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.NextPageColor}'>!8</font> -> {Application.Localizer["menu.button.next"]}");
+            builder.AppendFormat($"<font color='{centerHtmlMenu.NextPageColor}'>!8</font> -> {_nextLabel}");
             builder.AppendLine("<br>");
         }
 
         if (centerHtmlMenu.ExitButton)
         {
-            builder.AppendFormat($"<font color='{centerHtmlMenu.CloseColor}'>!9</font> -> {Application.Localizer["menu.button.close"]}");
+            builder.AppendFormat($"<font color='{centerHtmlMenu.CloseColor}'>!9</font> -> {_closeLabel}");
             builder.AppendLine("<br>");
         }
 
         SendPanel(builder.ToString());
+    }
+
+    // Display runs outside of command handling, where the thread culture is the server
+    // language rather than the player's, so the labels are read under the player's own
+    // language and kept until it changes.
+    private void RefreshLabels()
+    {
+        var language = Core.Translations.PlayerLanguageExtensions.GetLanguage(Player);
+        if (ReferenceEquals(_labelLanguage, language)) return;
+
+        using var culture = new Core.Translations.WithTemporaryCulture(language);
+        _previousLabel = Application.Localizer["menu.button.previous"];
+        _nextLabel = Application.Localizer["menu.button.next"];
+        _closeLabel = Application.Localizer["menu.button.close"];
+        _labelLanguage = language;
     }
 
     // The panel has to be resent on every tick to stay on screen, so building


### PR DESCRIPTION
`CenterHtmlMenuInstance.Display` is registered as an `OnTick` listener, and the panel only stays on screen while it is being resent, so an open menu rebuilds and resends its markup 64 times a second for every player looking at it. Two things in that path do not need to happen more than once.

### Measurements

Taken on a live CS2 server with a 12 item menu, timing the two halves of `Display` separately.

| | before | after |
|---|---:|---:|
| build markup | 31.3us | 3.7us |
| send panel | 35.6us | 29.0us |
| **per render** | **67us** | **33us** |

With twenty players holding a menu open that is 0.66ms of every tick instead of 1.34ms.

### What changed

**Labels and the builder** — the previous, next and close labels each go through the localization stack, and a `StringBuilder` is allocated, on every one of those 64 renders a second. None of it changes while the menu is open, so the labels are read when the menu is opened and one builder is reused.

**The panel event** — `PrintToCenterHtml` creates a game event, fires it and frees it. Doing that every tick is what most of an open menu costs. The event is kept for as long as the menu is and refilled with the new markup instead, then freed in `Close`. Sending is guarded the same way `PrintToCenterHtml` guards it.

The second measurement was taken by alternating the two send paths on every other render, so both meet the same conditions: 36.8us over 904 sends against 29.0us over 903. I first measured them one after the other and got a similar looking gain, but the untouched build time moved just as much between those two runs, so that pair said nothing and the interleaved one is what the number above comes from.

### Things I tried that did not work

Worth writing down so nobody repeats them.

**Resending less often than every tick.** The panel drops off screen almost immediately, at any interval above 1. Every tick really is required, so the resend itself cannot be avoided — only made cheaper, which is what the second commit does.

**Changing the duration passed to the event.** No observable difference at 1, 2, 5, 10 or 30, so whatever that field does it is not keeping the panel alive.

### Two things noticed while working on this, not addressed here

**The panel flickers.** It does so before these changes as well, at any resend rate, and it does the same on public servers running their own menu implementations, so it looks like it is how the game draws that panel when it is refreshed every tick rather than anything on this side.

**Menus are not closed when a player disconnects.** `ActiveMenus` is only cleaned by `CloseActiveMenu`, so an instance for a player who left keeps its `OnTick` listener and keeps rendering. That is pre-existing, and the event added here is freed in `Close` like the rest of the instance state, so it is not made worse, but it is why the guard is there.

Happy to split these into separate PRs if you would rather take them one at a time.
