### PR TITLE
feat: Add SoundEvent API for emitting sounds with parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,8 @@ set(SOURCE_FILES
     src/core/managers/usermessage_manager.cpp
     src/core/managers/usermessage_manager.h
     src/scripting/natives/natives_raytrace.cpp
+    src/scripting/natives/natives_sounds.cpp
+    src/core/sound_event.cpp
     src/scripting/natives/natives_dynamichooks.cpp
     src/core/game_system.h
     src/core/game_system.cpp

--- a/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
+++ b/managed/CounterStrikeSharp.API/Generated/Natives/API.cs
@@ -1690,26 +1690,6 @@ namespace CounterStrikeSharp.API.Core
 			}
 		}
 
-        public static IntPtr GetEconItemSystem(){
-			lock (ScriptContext.GlobalScriptContext.Lock) {
-			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.SetIdentifier(0x981E9B5B);
-			ScriptContext.GlobalScriptContext.Invoke();
-			ScriptContext.GlobalScriptContext.CheckErrors();
-			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
-			}
-		}
-
-        public static bool IsServerPaused(){
-			lock (ScriptContext.GlobalScriptContext.Lock) {
-			ScriptContext.GlobalScriptContext.Reset();
-			ScriptContext.GlobalScriptContext.SetIdentifier(0xB216AAAC);
-			ScriptContext.GlobalScriptContext.Invoke();
-			ScriptContext.GlobalScriptContext.CheckErrors();
-			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
-			}
-		}
-
         public static short GetSchemaOffset(string classname, string propname){
 			lock (ScriptContext.GlobalScriptContext.Lock) {
 			ScriptContext.GlobalScriptContext.Reset();
@@ -1794,6 +1774,107 @@ namespace CounterStrikeSharp.API.Core
 			ScriptContext.GlobalScriptContext.PushPrimitive(arrayindex);
 			ScriptContext.GlobalScriptContext.PushPrimitive(pathindex);
 			ScriptContext.GlobalScriptContext.SetIdentifier(0xBBE9D700);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
+        public static IntPtr GetEconItemSystem(){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x981E9B5B);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
+			}
+		}
+
+        public static bool IsServerPaused(){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.SetIdentifier(0xB216AAAC);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<bool>();
+			}
+		}
+
+        public static IntPtr SoundEventCreate(string name){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0xB724884E);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<IntPtr>();
+			}
+		}
+
+        public static void SoundEventRelease(IntPtr soundevent){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.PushPrimitive(soundevent);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0xFF002123);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
+        public static void SoundEventSetFloat(IntPtr soundevent, string name, float value){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.PushPrimitive(soundevent);
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x311228E7);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
+        public static void SoundEventSetInt(IntPtr soundevent, string name, int value){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.PushPrimitive(soundevent);
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x470A0744);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
+        public static void SoundEventSetVector(IntPtr soundevent, string name, IntPtr value){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.PushPrimitive(soundevent);
+			ScriptContext.GlobalScriptContext.PushString(name);
+			ScriptContext.GlobalScriptContext.PushPrimitive(value);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x2D238D2E);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			}
+		}
+
+        public static int SoundEventEmit(IntPtr soundevent, int sourceentityindex, ulong recipients){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.PushPrimitive(soundevent);
+			ScriptContext.GlobalScriptContext.PushPrimitive(sourceentityindex);
+			ScriptContext.GlobalScriptContext.PushPrimitive(recipients);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x30D4F65F);
+			ScriptContext.GlobalScriptContext.Invoke();
+			ScriptContext.GlobalScriptContext.CheckErrors();
+			return ScriptContext.GlobalScriptContext.GetResultPrimitive<int>();
+			}
+		}
+
+        public static void SoundEventStop(int guid, ulong recipients){
+			lock (ScriptContext.GlobalScriptContext.Lock) {
+			ScriptContext.GlobalScriptContext.Reset();
+			ScriptContext.GlobalScriptContext.PushPrimitive(guid);
+			ScriptContext.GlobalScriptContext.PushPrimitive(recipients);
+			ScriptContext.GlobalScriptContext.SetIdentifier(0x30DCA4D2);
 			ScriptContext.GlobalScriptContext.Invoke();
 			ScriptContext.GlobalScriptContext.CheckErrors();
 			}

--- a/managed/CounterStrikeSharp.API/Modules/Sounds/SoundEvent.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Sounds/SoundEvent.cs
@@ -1,0 +1,133 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>. *
+ */
+
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
+
+namespace CounterStrikeSharp.API.Modules.Sounds;
+
+/// <summary>
+/// A sound event built and sent as a network message, which lets sound operator parameters such
+/// as volume and pitch be chosen per emit.
+/// </summary>
+/// <example>
+/// <code>
+/// using var sound = new SoundEvent("Weapon_AK47.Single");
+/// sound.SourceEntityIndex = (int)player.Index;
+/// sound.SetParam(SoundEvent.Volume, 0.5f);
+/// sound.SetParam(SoundEvent.Pitch, 1.5f);
+/// sound.EmitToAll();
+/// </code>
+/// </example>
+public class SoundEvent : NativeObject, IDisposable
+{
+    /// <summary>Volume the sound plays at, where 1 leaves it unchanged.</summary>
+    public const string Volume = "public.volume";
+
+    /// <summary>Playback rate, where 1 leaves it unchanged, 2 raises it an octave and 0.5 lowers it one.</summary>
+    public const string Pitch = "public.pitch";
+
+    /// <summary>World position the sound plays from.</summary>
+    public const string Position = "public.position";
+
+    private bool _disposed;
+
+    /// <param name="name">Name of the sound event, for example <c>Weapon_AK47.Single</c>.</param>
+    /// <remarks>
+    /// The name is resolved by the client, so the server cannot tell a valid one from a typo. A name
+    /// that does not exist plays nothing and reports no error.
+    /// </remarks>
+    public SoundEvent(string name) : base(NativeAPI.SoundEventCreate(name))
+    {
+    }
+
+    /// <summary>
+    /// Entity the sound is attached to. Leave it at -1 to emit a sound with no source entity.
+    /// </summary>
+    public int SourceEntityIndex { get; set; } = -1;
+
+    /// <summary>
+    /// Sets a sound operator parameter. Setting the same parameter twice keeps the later value.
+    /// </summary>
+    /// <param name="name">
+    /// Any <c>public.*</c> parameter name. <see cref="Volume"/>, <see cref="Pitch"/> and
+    /// <see cref="Position"/> are the ones this API was tested against; whether any other parameter
+    /// has an effect depends on the operator stack behind the sound.
+    /// </param>
+    /// <param name="value">Value to send.</param>
+    public void SetParam(string name, float value) => NativeAPI.SoundEventSetFloat(Handle, name, value);
+
+    /// <inheritdoc cref="SetParam(string,float)"/>
+    public void SetParam(string name, int value) => NativeAPI.SoundEventSetInt(Handle, name, value);
+
+    /// <inheritdoc cref="SetParam(string,float)"/>
+    public void SetParam(string name, Vector value) => NativeAPI.SoundEventSetVector(Handle, name, value.Handle);
+
+    /// <summary>
+    /// Emits the sound to the given players.
+    /// </summary>
+    /// <returns>The guid the sound was started with, which <see cref="Stop"/> takes.</returns>
+    public int Emit(RecipientFilter recipients) =>
+        NativeAPI.SoundEventEmit(Handle, SourceEntityIndex, recipients.GetRecipientMask());
+
+    /// <inheritdoc cref="Emit"/>
+    public int EmitToAll()
+    {
+        var recipients = new RecipientFilter();
+        recipients.AddAllPlayers();
+
+        return Emit(recipients);
+    }
+
+    /// <inheritdoc cref="Emit"/>
+    public int EmitTo(CCSPlayerController player) => Emit(new RecipientFilter(player));
+
+    /// <summary>
+    /// Stops a sound started by <see cref="Emit"/>, using the guid it returned.
+    /// </summary>
+    public static void Stop(int guid, RecipientFilter? recipients = null)
+    {
+        if (recipients == null)
+        {
+            recipients = new RecipientFilter();
+            recipients.AddAllPlayers();
+        }
+
+        NativeAPI.SoundEventStop(guid, recipients.GetRecipientMask());
+    }
+
+    private void ReleaseUnmanagedResources()
+    {
+        if (_disposed) return;
+
+        _disposed = true;
+
+        // The finalizer runs off the game thread, where natives cannot be called.
+        var handle = Handle;
+        Server.NextFrame(() => NativeAPI.SoundEventRelease(handle));
+    }
+
+    public void Dispose()
+    {
+        ReleaseUnmanagedResources();
+        GC.SuppressFinalize(this);
+    }
+
+    ~SoundEvent()
+    {
+        ReleaseUnmanagedResources();
+    }
+}

--- a/managed/CounterStrikeSharp.API/Modules/Sounds/SoundEvent.cs
+++ b/managed/CounterStrikeSharp.API/Modules/Sounds/SoundEvent.cs
@@ -40,7 +40,10 @@ public class SoundEvent : NativeObject, IDisposable
     /// <summary>Playback rate, where 1 leaves it unchanged, 2 raises it an octave and 0.5 lowers it one.</summary>
     public const string Pitch = "public.pitch";
 
-    /// <summary>World position the sound plays from.</summary>
+    /// <summary>
+    /// World position the sound plays from. Takes effect with <see cref="SourceEntityIndex"/> set
+    /// to 0, and is ignored while the sound plays at the recipient or follows an entity.
+    /// </summary>
     public const string Position = "public.position";
 
     private bool _disposed;
@@ -55,7 +58,12 @@ public class SoundEvent : NativeObject, IDisposable
     }
 
     /// <summary>
-    /// Entity the sound is attached to. Leave it at -1 to emit a sound with no source entity.
+    /// Where the sound plays from.
+    /// <list type="bullet">
+    /// <item><description>-1, the default, plays it at each recipient, and <see cref="Position"/> is ignored.</description></item>
+    /// <item><description>0 plays it at <see cref="Position"/> in the world, which is how the game emits placed sounds.</description></item>
+    /// <item><description>Any other index attaches it to that entity and follows it.</description></item>
+    /// </list>
     /// </summary>
     public int SourceEntityIndex { get; set; } = -1;
 
@@ -64,8 +72,8 @@ public class SoundEvent : NativeObject, IDisposable
     /// </summary>
     /// <param name="name">
     /// Any <c>public.*</c> parameter name. <see cref="Volume"/>, <see cref="Pitch"/> and
-    /// <see cref="Position"/> are the ones this API was tested against; whether any other parameter
-    /// has an effect depends on the operator stack behind the sound.
+    /// <see cref="Position"/> are the ones verified to change what the player hears. Every parameter
+    /// reaches the client, but whether it has an effect depends on the operator stack behind the sound.
     /// </param>
     /// <param name="value">Value to send.</param>
     public void SetParam(string name, float value) => NativeAPI.SoundEventSetFloat(Handle, name, value);

--- a/managed/CounterStrikeSharp.Tests.Native/SoundEventTests.cs
+++ b/managed/CounterStrikeSharp.Tests.Native/SoundEventTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Sounds;
+using CounterStrikeSharp.API.Modules.UserMessages;
+using Xunit;
+using Vector = CounterStrikeSharp.API.Modules.Utils.Vector;
+
+namespace NativeTestsPlugin;
+
+public class SoundEventTests
+{
+    // gameevents.proto: GE_SosStartSoundEvent
+    private const int SosStartSoundEvent = 208;
+
+    private const string TestSound = "Weapon_AK47.Single";
+
+    // MurmurHash2 of the parameter name under the Source 2 string token seed. Hardcoded so that a
+    // change to the way parameters are packed shows up as a failing test rather than silence.
+    private const uint VolumeHash = 0xBD6054E9;
+    private const uint PitchHash = 0x929A57A4;
+    private const uint PositionHash = 0x5A7CCE4D;
+
+    private const byte TypeInt = 0x02;
+    private const byte TypeFloat = 0x08;
+    private const byte TypeVector = 0x0A;
+
+    private readonly record struct Parameter(uint Hash, byte Type, byte[] Value);
+
+    private readonly record struct CapturedSound(uint Guid, uint Hash, byte[]? Packed);
+
+    /// <summary>
+    /// Runs <paramref name="emit"/> with a hook on the sound event message and returns what the
+    /// hook saw. Values are read inside the hook because the message only lives for that call, and
+    /// the game may well emit its own sounds in the same frame, so callers pick theirs out by guid.
+    /// </summary>
+    private static List<CapturedSound> Capture(Action emit)
+    {
+        var captured = new List<CapturedSound>();
+
+        HookResult Handler(UserMessage message)
+        {
+            captured.Add(new CapturedSound(message.ReadUInt("soundevent_guid"), message.ReadUInt("soundevent_hash"),
+                message.HasField("packed_params") ? message.ReadBytes("packed_params") : null));
+
+            return HookResult.Continue;
+        }
+
+        NativeTestsPlugin.Instance.HookUserMessage(SosStartSoundEvent, Handler);
+
+        try
+        {
+            emit();
+        }
+        finally
+        {
+            NativeTestsPlugin.Instance.UnhookUserMessage(SosStartSoundEvent, Handler);
+        }
+
+        return captured;
+    }
+
+    /// <summary>
+    /// Emits one sound and returns the message it produced.
+    /// </summary>
+    private static CapturedSound EmitAndCapture(Action<SoundEvent> setup)
+    {
+        var guid = 0;
+
+        var captured = Capture(() =>
+        {
+            using var sound = new SoundEvent(TestSound);
+            setup(sound);
+            guid = sound.EmitToAll();
+        });
+
+        Assert.NotEqual(0, guid);
+
+        return Assert.Single(captured, sound => sound.Guid == (uint)guid);
+    }
+
+    private static List<Parameter> Unpack(byte[] packed)
+    {
+        var parameters = new List<Parameter>();
+
+        for (var at = 0; at + 7 <= packed.Length;)
+        {
+            var hash = BitConverter.ToUInt32(packed, at);
+            var type = packed[at + 4];
+            var size = BitConverter.ToUInt16(packed, at + 5);
+            at += 7;
+
+            Assert.True(at + size <= packed.Length, "parameter runs past the end of the blob");
+            parameters.Add(new Parameter(hash, type, packed[at..(at + size)]));
+            at += size;
+        }
+
+        return parameters;
+    }
+
+    [Fact]
+    public void Create_ReturnsValidHandle()
+    {
+        using var sound = new SoundEvent(TestSound);
+
+        Assert.NotEqual(IntPtr.Zero, sound.Handle);
+    }
+
+    [Fact]
+    public async Task Emit_ReturnsIncreasingGuids()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            using var first = new SoundEvent(TestSound);
+            using var second = new SoundEvent(TestSound);
+
+            var firstGuid = first.EmitToAll();
+            var secondGuid = second.EmitToAll();
+
+            Assert.NotEqual(0, firstGuid);
+            Assert.True(secondGuid > firstGuid, $"expected guid {secondGuid} to follow {firstGuid}");
+        });
+    }
+
+    [Fact]
+    public async Task Emit_HashesTheSoundNameTheWayTheGameDoes()
+    {
+        // A sound the bots will not set off by themselves, so anything the game emits under this
+        // hash came from the EmitSound call below.
+        const string quietSound = "UIPanorama.popup_accept_match_beep";
+
+        var seen = new List<CapturedSound>();
+        var ourGuid = 0u;
+
+        HookResult Handler(UserMessage message)
+        {
+            seen.Add(new CapturedSound(message.ReadUInt("soundevent_guid"), message.ReadUInt("soundevent_hash"),
+                message.HasField("packed_params") ? message.ReadBytes("packed_params") : null));
+
+            return HookResult.Continue;
+        }
+
+        await Server.NextFrameAsync(() =>
+        {
+            var player = Utilities.GetPlayers().FirstOrDefault(p => p is { IsValid: true });
+            Assert.NotNull(player);
+
+            NativeTestsPlugin.Instance.HookUserMessage(SosStartSoundEvent, Handler);
+
+            using (var sound = new SoundEvent(quietSound))
+            {
+                sound.SourceEntityIndex = (int)player!.Index;
+                ourGuid = (uint)sound.EmitToAll();
+            }
+
+            // The game does not post its own message inside this call, hence the wait below.
+            player!.EmitSound(quietSound);
+        });
+
+        await TestUtils.WaitForSeconds(0.6f);
+        await Server.NextFrameAsync(() => NativeTestsPlugin.Instance.UnhookUserMessage(SosStartSoundEvent, Handler));
+
+        var ours = Assert.Single(seen, sound => sound.Guid == ourGuid);
+        var theirs = seen.Where(sound => sound.Guid != ourGuid).ToList();
+
+        Assert.NotEmpty(theirs);
+        Assert.Contains(theirs, sound => sound.Hash == ours.Hash);
+    }
+
+    [Fact]
+    public async Task SetParam_PacksEveryParameterIntoTheMessage()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            var captured = EmitAndCapture(sound =>
+            {
+                sound.SetParam(SoundEvent.Volume, 0.25f);
+                sound.SetParam(SoundEvent.Pitch, 1.5f);
+                sound.SetParam(SoundEvent.Position, new Vector(1, 2, 3));
+            });
+
+            Assert.NotNull(captured.Packed);
+            var parameters = Unpack(captured.Packed!);
+            Assert.Equal(3, parameters.Count);
+
+            var volume = parameters.Single(p => p.Hash == VolumeHash);
+            Assert.Equal(TypeFloat, volume.Type);
+            Assert.Equal(0.25f, BitConverter.ToSingle(volume.Value));
+
+            var pitch = parameters.Single(p => p.Hash == PitchHash);
+            Assert.Equal(TypeFloat, pitch.Type);
+            Assert.Equal(1.5f, BitConverter.ToSingle(pitch.Value));
+
+            var position = parameters.Single(p => p.Hash == PositionHash);
+            Assert.Equal(TypeVector, position.Type);
+            Assert.Equal(12, position.Value.Length);
+            Assert.Equal(1f, BitConverter.ToSingle(position.Value, 0));
+            Assert.Equal(2f, BitConverter.ToSingle(position.Value, 4));
+            Assert.Equal(3f, BitConverter.ToSingle(position.Value, 8));
+        });
+    }
+
+    [Fact]
+    public async Task SetParam_SameParameterTwice_SendsOnlyTheLastValue()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            var captured = EmitAndCapture(sound =>
+            {
+                sound.SetParam(SoundEvent.Volume, 0.1f);
+                sound.SetParam(SoundEvent.Volume, 0.9f);
+            });
+
+            Assert.NotNull(captured.Packed);
+            var volume = Assert.Single(Unpack(captured.Packed!), p => p.Hash == VolumeHash);
+            Assert.Equal(0.9f, BitConverter.ToSingle(volume.Value));
+        });
+    }
+
+    [Fact]
+    public async Task SetParam_Int_UsesTheIntegerType()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            var captured = EmitAndCapture(sound => sound.SetParam("public.relevant_player", 7));
+
+            Assert.NotNull(captured.Packed);
+            var parameter = Assert.Single(Unpack(captured.Packed!));
+            Assert.Equal(TypeInt, parameter.Type);
+            Assert.Equal(7, BitConverter.ToInt32(parameter.Value));
+        });
+    }
+
+    [Fact]
+    public async Task Emit_WithNoParameters_SendsNoBlob()
+    {
+        await Server.NextFrameAsync(() => { Assert.Null(EmitAndCapture(_ => { }).Packed); });
+    }
+}

--- a/managed/CounterStrikeSharp.Tests.Native/SoundEventTests.cs
+++ b/managed/CounterStrikeSharp.Tests.Native/SoundEventTests.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Sounds;
-using CounterStrikeSharp.API.Modules.UserMessages;
+using CounterStrikeSharp.API.Modules.Utils;
 using Xunit;
 using Vector = CounterStrikeSharp.API.Modules.Utils.Vector;
 
@@ -13,92 +12,14 @@ namespace NativeTestsPlugin;
 
 public class SoundEventTests
 {
-    // gameevents.proto: GE_SosStartSoundEvent
-    private const int SosStartSoundEvent = 208;
-
     private const string TestSound = "Weapon_AK47.Single";
 
-    // MurmurHash2 of the parameter name under the Source 2 string token seed. Hardcoded so that a
-    // change to the way parameters are packed shows up as a failing test rather than silence.
-    private const uint VolumeHash = 0xBD6054E9;
-    private const uint PitchHash = 0x929A57A4;
-    private const uint PositionHash = 0x5A7CCE4D;
-
-    private const byte TypeInt = 0x02;
-    private const byte TypeFloat = 0x08;
-    private const byte TypeVector = 0x0A;
-
-    private readonly record struct Parameter(uint Hash, byte Type, byte[] Value);
-
-    private readonly record struct CapturedSound(uint Guid, uint Hash, byte[]? Packed);
-
-    /// <summary>
-    /// Runs <paramref name="emit"/> with a hook on the sound event message and returns what the
-    /// hook saw. Values are read inside the hook because the message only lives for that call, and
-    /// the game may well emit its own sounds in the same frame, so callers pick theirs out by guid.
-    /// </summary>
-    private static List<CapturedSound> Capture(Action emit)
+    private static CCSPlayerController FindPlayer()
     {
-        var captured = new List<CapturedSound>();
+        var player = Utilities.GetPlayers().FirstOrDefault(p => p is { IsValid: true });
+        Assert.NotNull(player);
 
-        HookResult Handler(UserMessage message)
-        {
-            captured.Add(new CapturedSound(message.ReadUInt("soundevent_guid"), message.ReadUInt("soundevent_hash"),
-                message.HasField("packed_params") ? message.ReadBytes("packed_params") : null));
-
-            return HookResult.Continue;
-        }
-
-        NativeTestsPlugin.Instance.HookUserMessage(SosStartSoundEvent, Handler);
-
-        try
-        {
-            emit();
-        }
-        finally
-        {
-            NativeTestsPlugin.Instance.UnhookUserMessage(SosStartSoundEvent, Handler);
-        }
-
-        return captured;
-    }
-
-    /// <summary>
-    /// Emits one sound and returns the message it produced.
-    /// </summary>
-    private static CapturedSound EmitAndCapture(Action<SoundEvent> setup)
-    {
-        var guid = 0;
-
-        var captured = Capture(() =>
-        {
-            using var sound = new SoundEvent(TestSound);
-            setup(sound);
-            guid = sound.EmitToAll();
-        });
-
-        Assert.NotEqual(0, guid);
-
-        return Assert.Single(captured, sound => sound.Guid == (uint)guid);
-    }
-
-    private static List<Parameter> Unpack(byte[] packed)
-    {
-        var parameters = new List<Parameter>();
-
-        for (var at = 0; at + 7 <= packed.Length;)
-        {
-            var hash = BitConverter.ToUInt32(packed, at);
-            var type = packed[at + 4];
-            var size = BitConverter.ToUInt16(packed, at + 5);
-            at += 7;
-
-            Assert.True(at + size <= packed.Length, "parameter runs past the end of the blob");
-            parameters.Add(new Parameter(hash, type, packed[at..(at + size)]));
-            at += size;
-        }
-
-        return parameters;
+        return player!;
     }
 
     [Fact]
@@ -126,117 +47,123 @@ public class SoundEventTests
     }
 
     [Fact]
-    public async Task Emit_HashesTheSoundNameTheWayTheGameDoes()
+    public async Task SetParam_AcceptsEveryValueType()
     {
-        // A sound the bots will not set off by themselves, so anything the game emits under this
-        // hash came from the EmitSound call below.
-        const string quietSound = "UIPanorama.popup_accept_match_beep";
-
-        var seen = new List<CapturedSound>();
-        var ourGuid = 0u;
-
-        HookResult Handler(UserMessage message)
-        {
-            seen.Add(new CapturedSound(message.ReadUInt("soundevent_guid"), message.ReadUInt("soundevent_hash"),
-                message.HasField("packed_params") ? message.ReadBytes("packed_params") : null));
-
-            return HookResult.Continue;
-        }
-
         await Server.NextFrameAsync(() =>
         {
-            var player = Utilities.GetPlayers().FirstOrDefault(p => p is { IsValid: true });
-            Assert.NotNull(player);
+            using var sound = new SoundEvent(TestSound);
+            sound.SourceEntityIndex = (int)FindPlayer().Index;
+            sound.SetParam(SoundEvent.Volume, 0.5f);
+            sound.SetParam(SoundEvent.Pitch, 1.5f);
+            sound.SetParam(SoundEvent.Position, new Vector(1, 2, 3));
+            sound.SetParam("public.relevant_player", 1);
 
-            NativeTestsPlugin.Instance.HookUserMessage(SosStartSoundEvent, Handler);
+            Assert.NotEqual(0, sound.EmitToAll());
+        });
+    }
 
-            using (var sound = new SoundEvent(quietSound))
+    [Fact]
+    public async Task SetParam_SameParameterTwice_KeepsWorking()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            using var sound = new SoundEvent(TestSound);
+            sound.SetParam(SoundEvent.Volume, 0.1f);
+            sound.SetParam(SoundEvent.Volume, 0.9f);
+
+            Assert.NotEqual(0, sound.EmitToAll());
+        });
+    }
+
+    [Fact]
+    public async Task EmitTo_SendsToASinglePlayer()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            using var sound = new SoundEvent(TestSound);
+
+            Assert.NotEqual(0, sound.EmitTo(FindPlayer()));
+        });
+    }
+
+    [Fact]
+    public async Task Stop_EndsASoundThatWasStarted()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            using var sound = new SoundEvent(TestSound);
+            var guid = sound.EmitToAll();
+
+            SoundEvent.Stop(guid);
+        });
+    }
+
+    [Fact]
+    public async Task Dispose_IsSafeToCallTwice()
+    {
+        await Server.NextFrameAsync(() =>
+        {
+            var sound = new SoundEvent(TestSound);
+            sound.EmitToAll();
+
+            sound.Dispose();
+            sound.Dispose();
+        });
+    }
+}
+
+/// <summary>
+/// Plays a sound to every player on the server, sweeping volume, pitch and then position so that the
+/// result can be checked by ear. Run it on its own with <c>css_itest AudibleSoundTest</c>.
+/// </summary>
+public class AudibleSoundTest
+{
+    private const string SweepSound = "Weapon_AK47.Single";
+
+    private static void Play(float volume, float pitch, float sideways = 0f)
+    {
+        foreach (var player in Utilities.GetPlayers().Where(p => p is { IsValid: true, IsBot: false }))
+        {
+            using var sound = new SoundEvent(SweepSound);
+            sound.SetParam(SoundEvent.Volume, volume);
+            sound.SetParam(SoundEvent.Pitch, pitch);
+
+            var origin = player.PlayerPawn.Value?.AbsOrigin;
+            if (sideways != 0f && origin != null)
             {
-                sound.SourceEntityIndex = (int)player!.Index;
-                ourGuid = (uint)sound.EmitToAll();
+                // 0 places the sound in the world rather than at the listener.
+                sound.SourceEntityIndex = 0;
+                sound.SetParam(SoundEvent.Position, new Vector(origin.X + sideways, origin.Y, origin.Z));
             }
 
-            // The game does not post its own message inside this call, hence the wait below.
-            player!.EmitSound(quietSound);
-        });
-
-        await TestUtils.WaitForSeconds(0.6f);
-        await Server.NextFrameAsync(() => NativeTestsPlugin.Instance.UnhookUserMessage(SosStartSoundEvent, Handler));
-
-        var ours = Assert.Single(seen, sound => sound.Guid == ourGuid);
-        var theirs = seen.Where(sound => sound.Guid != ourGuid).ToList();
-
-        Assert.NotEmpty(theirs);
-        Assert.Contains(theirs, sound => sound.Hash == ours.Hash);
+            sound.EmitTo(player);
+        }
     }
 
-    [Fact]
-    public async Task SetParam_PacksEveryParameterIntoTheMessage()
+    private static async Task Step(string what, float volume, float pitch, float sideways = 0f)
     {
         await Server.NextFrameAsync(() =>
         {
-            var captured = EmitAndCapture(sound =>
-            {
-                sound.SetParam(SoundEvent.Volume, 0.25f);
-                sound.SetParam(SoundEvent.Pitch, 1.5f);
-                sound.SetParam(SoundEvent.Position, new Vector(1, 2, 3));
-            });
-
-            Assert.NotNull(captured.Packed);
-            var parameters = Unpack(captured.Packed!);
-            Assert.Equal(3, parameters.Count);
-
-            var volume = parameters.Single(p => p.Hash == VolumeHash);
-            Assert.Equal(TypeFloat, volume.Type);
-            Assert.Equal(0.25f, BitConverter.ToSingle(volume.Value));
-
-            var pitch = parameters.Single(p => p.Hash == PitchHash);
-            Assert.Equal(TypeFloat, pitch.Type);
-            Assert.Equal(1.5f, BitConverter.ToSingle(pitch.Value));
-
-            var position = parameters.Single(p => p.Hash == PositionHash);
-            Assert.Equal(TypeVector, position.Type);
-            Assert.Equal(12, position.Value.Length);
-            Assert.Equal(1f, BitConverter.ToSingle(position.Value, 0));
-            Assert.Equal(2f, BitConverter.ToSingle(position.Value, 4));
-            Assert.Equal(3f, BitConverter.ToSingle(position.Value, 8));
+            Server.PrintToChatAll($" \x04{what}");
+            Play(volume, pitch, sideways);
         });
+
+        await TestUtils.WaitForSeconds(1.2f);
     }
 
     [Fact]
-    public async Task SetParam_SameParameterTwice_SendsOnlyTheLastValue()
+    public async Task SweepsVolumeThenPitchThenPosition()
     {
-        await Server.NextFrameAsync(() =>
-        {
-            var captured = EmitAndCapture(sound =>
-            {
-                sound.SetParam(SoundEvent.Volume, 0.1f);
-                sound.SetParam(SoundEvent.Volume, 0.9f);
-            });
+        await Step("volume 0.1", 0.1f, 1.0f);
+        await Step("volume 0.4", 0.4f, 1.0f);
+        await Step("volume 1.0, louder each time", 1.0f, 1.0f);
 
-            Assert.NotNull(captured.Packed);
-            var volume = Assert.Single(Unpack(captured.Packed!), p => p.Hash == VolumeHash);
-            Assert.Equal(0.9f, BitConverter.ToSingle(volume.Value));
-        });
-    }
+        await Step("pitch 0.5, lower", 1.0f, 0.5f);
+        await Step("pitch 1.0", 1.0f, 1.0f);
+        await Step("pitch 2.0, higher", 1.0f, 2.0f);
 
-    [Fact]
-    public async Task SetParam_Int_UsesTheIntegerType()
-    {
-        await Server.NextFrameAsync(() =>
-        {
-            var captured = EmitAndCapture(sound => sound.SetParam("public.relevant_player", 7));
-
-            Assert.NotNull(captured.Packed);
-            var parameter = Assert.Single(Unpack(captured.Packed!));
-            Assert.Equal(TypeInt, parameter.Type);
-            Assert.Equal(7, BitConverter.ToInt32(parameter.Value));
-        });
-    }
-
-    [Fact]
-    public async Task Emit_WithNoParameters_SendsNoBlob()
-    {
-        await Server.NextFrameAsync(() => { Assert.Null(EmitAndCapture(_ => { }).Packed); });
+        await Step("at the listener", 1.0f, 1.0f);
+        await Step("600 units to the side", 1.0f, 1.0f, 600f);
+        await Step("2500 units to the side, further off", 1.0f, 1.0f, 2500f);
     }
 }

--- a/src/core/sound_event.cpp
+++ b/src/core/sound_event.cpp
@@ -1,0 +1,149 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "core/sound_event.h"
+
+#include <cstring>
+
+#include "core/globals.h"
+#include "core/log.h"
+#include "core/recipientfilters.h"
+#include "gameevents.pb.h"
+#include "igameeventsystem.h"
+#include "networksystem/inetworkmessages.h"
+#include "tier1/generichash.h"
+#include "tier1/utlstringtoken.h"
+
+namespace counterstrikesharp {
+
+namespace {
+// The game numbers its own sound events up from zero, so start well clear of them. Sharing a
+// guid with a game sound would let one Stop call silence the other.
+int32 g_nNextSoundEventGuid = 1 << 24;
+} // namespace
+
+SoundEvent::SoundEvent(const char* pszSoundEventName)
+    : m_nSoundEventHash(MurmurHash2LowerCase(pszSoundEventName, SOUNDEVENT_MURMURHASH_SEED))
+{
+}
+
+void SoundEvent::SetParameter(const char* pszParameterName, ParameterType type, const void* pValue, uint16 nSize)
+{
+    // A parameter is a 32 bit name hash, a type tag, a 16 bit length, then the value.
+    static constexpr size_t kHeaderSize = sizeof(uint32) + sizeof(uint8) + sizeof(uint16);
+
+    const uint32 nParameterHash = MurmurHash2LowerCase(pszParameterName, STRINGTOKEN_MURMURHASH_SEED);
+    const uint8 nType = static_cast<uint8>(type);
+
+    // Drop any earlier value for this parameter, so that setting one twice sends it once.
+    for (size_t at = 0; at + kHeaderSize <= m_packedParameters.size();)
+    {
+        uint32 nExistingHash;
+        uint16 nExistingSize;
+        memcpy(&nExistingHash, &m_packedParameters[at], sizeof(nExistingHash));
+        memcpy(&nExistingSize, &m_packedParameters[at + sizeof(uint32) + sizeof(uint8)], sizeof(nExistingSize));
+
+        const size_t next = at + kHeaderSize + nExistingSize;
+        if (next > m_packedParameters.size()) break;
+
+        if (nExistingHash == nParameterHash)
+        {
+            m_packedParameters.erase(m_packedParameters.begin() + at, m_packedParameters.begin() + next);
+            break;
+        }
+
+        at = next;
+    }
+
+    // Values go out in the byte order they are already in, which is what the client reads.
+    const size_t at = m_packedParameters.size();
+    m_packedParameters.resize(at + kHeaderSize + nSize);
+
+    uint8* pOut = m_packedParameters.data() + at;
+    memcpy(pOut, &nParameterHash, sizeof(nParameterHash));
+    pOut += sizeof(nParameterHash);
+    memcpy(pOut, &nType, sizeof(nType));
+    pOut += sizeof(nType);
+    memcpy(pOut, &nSize, sizeof(nSize));
+    pOut += sizeof(nSize);
+    memcpy(pOut, pValue, nSize);
+}
+
+void SoundEvent::SetFloat(const char* pszParameterName, float value)
+{
+    SetParameter(pszParameterName, Parameter_Float, &value, sizeof(value));
+}
+
+void SoundEvent::SetInt(const char* pszParameterName, int32 value) { SetParameter(pszParameterName, Parameter_Int, &value, sizeof(value)); }
+
+void SoundEvent::SetVector(const char* pszParameterName, const Vector& value)
+{
+    const float coordinates[3] = { value.x, value.y, value.z };
+    SetParameter(pszParameterName, Parameter_Vector, coordinates, sizeof(coordinates));
+}
+
+int32 SoundEvent::Emit(int32 nSourceEntityIndex, uint64 recipientMask)
+{
+    INetworkMessageInternal* pNetMsg = globals::networkMessages->FindNetworkMessageById(GE_SosStartSoundEvent);
+    if (!pNetMsg)
+    {
+        CSSHARP_CORE_ERROR("[SoundEvent] Failed to find the SosStartSoundEvent network message");
+        return 0;
+    }
+
+    const int32 nGuid = g_nNextSoundEventGuid++;
+
+    auto msg = pNetMsg->AllocateMessage()->ToPB<CMsgSosStartSoundEvent>();
+    msg->set_soundevent_guid(nGuid);
+    msg->set_soundevent_hash(m_nSoundEventHash);
+    msg->set_source_entity_index(nSourceEntityIndex);
+    msg->set_seed(nGuid);
+
+    if (!m_packedParameters.empty())
+    {
+        msg->set_packed_params(m_packedParameters.data(), m_packedParameters.size());
+    }
+
+    CRecipientFilter filter{};
+    filter.AddRecipientsFromMask(recipientMask);
+
+    globals::gameEventSystem->PostEventAbstract(-1, false, &filter, pNetMsg, msg, 0);
+
+    delete msg;
+    return nGuid;
+}
+
+void SoundEvent::Stop(int32 nGuid, uint64 recipientMask)
+{
+    INetworkMessageInternal* pNetMsg = globals::networkMessages->FindNetworkMessageById(GE_SosStopSoundEvent);
+    if (!pNetMsg)
+    {
+        CSSHARP_CORE_ERROR("[SoundEvent] Failed to find the SosStopSoundEvent network message");
+        return;
+    }
+
+    auto msg = pNetMsg->AllocateMessage()->ToPB<CMsgSosStopSoundEvent>();
+    msg->set_soundevent_guid(nGuid);
+
+    CRecipientFilter filter{};
+    filter.AddRecipientsFromMask(recipientMask);
+
+    globals::gameEventSystem->PostEventAbstract(-1, false, &filter, pNetMsg, msg, 0);
+
+    delete msg;
+}
+
+} // namespace counterstrikesharp

--- a/src/core/sound_event.h
+++ b/src/core/sound_event.h
@@ -1,0 +1,61 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "mathlib/vector.h"
+#include "platform.h"
+
+namespace counterstrikesharp {
+
+// Sound event names are hashed with their own seed rather than the string token seed that
+// the sound operator parameter names use.
+#define SOUNDEVENT_MURMURHASH_SEED 0x53524332
+
+// Builds the parameter blob carried by CMsgSosStartSoundEvent. The blob is a flat sequence of
+// parameters, each one a 32 bit hash of the parameter name, a type tag, a 16 bit length and
+// then the value.
+class SoundEvent
+{
+  public:
+    explicit SoundEvent(const char* pszSoundEventName);
+
+    void SetFloat(const char* pszParameterName, float value);
+    void SetInt(const char* pszParameterName, int32 value);
+    void SetVector(const char* pszParameterName, const Vector& value);
+
+    // Returns the guid the sound was started with, which Stop takes to end it early.
+    int32 Emit(int32 nSourceEntityIndex, uint64 recipientMask);
+
+    static void Stop(int32 nGuid, uint64 recipientMask);
+
+  private:
+    enum ParameterType : uint8
+    {
+        Parameter_Int = 0x02,
+        Parameter_Float = 0x08,
+        Parameter_Vector = 0x0A,
+    };
+
+    void SetParameter(const char* pszParameterName, ParameterType type, const void* pValue, uint16 nSize);
+
+    uint32 m_nSoundEventHash;
+    std::vector<uint8> m_packedParameters;
+};
+
+} // namespace counterstrikesharp

--- a/src/scripting/natives/natives_sounds.cpp
+++ b/src/scripting/natives/natives_sounds.cpp
@@ -1,0 +1,115 @@
+/*
+ *  This file is part of CounterStrikeSharp.
+ *  CounterStrikeSharp is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  CounterStrikeSharp is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CounterStrikeSharp.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "core/log.h"
+#include "core/sound_event.h"
+#include "scripting/autonative.h"
+#include "scripting/script_engine.h"
+
+namespace counterstrikesharp {
+
+static SoundEvent* GetSoundEvent(ScriptContext& script_context)
+{
+    auto soundEvent = script_context.GetArgument<SoundEvent*>(0);
+    if (!soundEvent)
+    {
+        script_context.ThrowNativeError("Invalid sound event pointer");
+        return nullptr;
+    }
+
+    return soundEvent;
+}
+
+static void SoundEventCreate(ScriptContext& script_context)
+{
+    auto name = script_context.GetArgument<const char*>(0);
+    if (!name || name[0] == '\0')
+    {
+        script_context.ThrowNativeError("Sound event name cannot be empty");
+        return;
+    }
+
+    script_context.SetResult(new SoundEvent(name));
+}
+
+static void SoundEventRelease(ScriptContext& script_context)
+{
+    auto soundEvent = GetSoundEvent(script_context);
+    if (!soundEvent) return;
+
+    delete soundEvent;
+}
+
+static void SoundEventSetFloat(ScriptContext& script_context)
+{
+    auto soundEvent = GetSoundEvent(script_context);
+    if (!soundEvent) return;
+
+    soundEvent->SetFloat(script_context.GetArgument<const char*>(1), script_context.GetArgument<float>(2));
+}
+
+static void SoundEventSetInt(ScriptContext& script_context)
+{
+    auto soundEvent = GetSoundEvent(script_context);
+    if (!soundEvent) return;
+
+    soundEvent->SetInt(script_context.GetArgument<const char*>(1), script_context.GetArgument<int32>(2));
+}
+
+static void SoundEventSetVector(ScriptContext& script_context)
+{
+    auto soundEvent = GetSoundEvent(script_context);
+    if (!soundEvent) return;
+
+    auto value = script_context.GetArgument<Vector*>(2);
+    if (!value)
+    {
+        script_context.ThrowNativeError("Invalid vector pointer");
+        return;
+    }
+
+    soundEvent->SetVector(script_context.GetArgument<const char*>(1), *value);
+}
+
+static int32 SoundEventEmit(ScriptContext& script_context)
+{
+    auto soundEvent = GetSoundEvent(script_context);
+    if (!soundEvent) return 0;
+
+    auto sourceEntityIndex = script_context.GetArgument<int32>(1);
+    auto recipientMask = script_context.GetArgument<uint64>(2);
+
+    return soundEvent->Emit(sourceEntityIndex, recipientMask);
+}
+
+static void SoundEventStop(ScriptContext& script_context)
+{
+    auto guid = script_context.GetArgument<int32>(0);
+    auto recipientMask = script_context.GetArgument<uint64>(1);
+
+    SoundEvent::Stop(guid, recipientMask);
+}
+
+REGISTER_NATIVES(sounds, {
+    ScriptEngine::RegisterNativeHandler("SOUND_EVENT_CREATE", SoundEventCreate);
+    ScriptEngine::RegisterNativeHandler("SOUND_EVENT_RELEASE", SoundEventRelease);
+    ScriptEngine::RegisterNativeHandler("SOUND_EVENT_SET_FLOAT", SoundEventSetFloat);
+    ScriptEngine::RegisterNativeHandler("SOUND_EVENT_SET_INT", SoundEventSetInt);
+    ScriptEngine::RegisterNativeHandler("SOUND_EVENT_SET_VECTOR", SoundEventSetVector);
+    ScriptEngine::RegisterNativeHandler("SOUND_EVENT_EMIT", SoundEventEmit);
+    ScriptEngine::RegisterNativeHandler("SOUND_EVENT_STOP", SoundEventStop);
+})
+} // namespace counterstrikesharp

--- a/src/scripting/natives/natives_sounds.yaml
+++ b/src/scripting/natives/natives_sounds.yaml
@@ -1,0 +1,7 @@
+SOUND_EVENT_CREATE: name:string -> pointer
+SOUND_EVENT_RELEASE: soundEvent:pointer -> void
+SOUND_EVENT_SET_FLOAT: soundEvent:pointer, name:string, value:float -> void
+SOUND_EVENT_SET_INT: soundEvent:pointer, name:string, value:int -> void
+SOUND_EVENT_SET_VECTOR: soundEvent:pointer, name:string, value:pointer -> void
+SOUND_EVENT_EMIT: soundEvent:pointer, sourceEntityIndex:int, recipients:uint64 -> int
+SOUND_EVENT_STOP: guid:int, recipients:uint64 -> void


### PR DESCRIPTION
`EmitSound` takes volume and pitch arguments that never reach the client. It goes through `CBaseEntity::EmitSoundFilter`, and the `CMsgSosStartSoundEvent` that comes out of it carries no `packed_params` at all, so there is nothing for the client to apply. Captured from a live server, this is the whole message the current path sends:

```
soundevent_guid=347 soundevent_hash=3838664315 source_entity_index=5 seed=347
```

The source already says as much: `m_nPitch` is annotated "not working, can't fix, i think the game abandon it", and `m_flVolume` is a `volume_atten` rather than a volume. This was raised in #919, and #126 is still open.

This adds a `SoundEvent` that builds the message directly, so sound operator parameters can be chosen per emit.

```csharp
using var sound = new SoundEvent("Weapon_AK47.Single");
sound.SourceEntityIndex = (int)player.Index;
sound.SetParam(SoundEvent.Volume, 0.5f);
sound.SetParam(SoundEvent.Pitch, 1.5f);
sound.EmitToAll();
```

`Emit` returns the guid, which `SoundEvent.Stop` takes to end a sound early. Recipients come from a `RecipientFilter`, so a sound can go to one player, one team, or everyone.

`SetParam` takes any `public.*` parameter name, not a fixed set, so anything the sound's operator stack reads can be driven from a plugin without a change here first:

```csharp
sound.SetParam("public.velocity", 250f);
sound.SetParam(SoundEvent.Position, new Vector(0, 0, 0));
```

Volume, pitch and position are the three this was tested against. Whether any other parameter does something depends on the stack behind the sound, which is noted in the API documentation.

## Implementation

Built on the core side using net messages, which is the approach suggested in the discussion.

`packed_params` is a flat sequence of parameters, each one a 32 bit hash of the parameter name, a type tag, a 16 bit length, then the value. The types that appear in game traffic are `0x02` for integers, `0x08` for floats and `0x0A` for vectors. Parsing 365 parameters captured from ordinary gameplay leaves no remainder.

Two seeds are in play, and both go through the SDK's own `MurmurHash2LowerCase`: sound event names hash with `0x53524332`, parameter names with `STRINGTOKEN_MURMURHASH_SEED`. Nothing about hashing is reimplemented here.

`SetParam` replaces an earlier value for the same parameter rather than appending one, so a reused sound event does not grow its blob.

`EmitSound` is left alone, so no existing behaviour changes.

## Verification

Checked against the current game build on a live server:

- the hash this produces for a sound name is identical to the one the game puts in its own message for that name
- volume and pitch are audibly different across values, where the existing `EmitSound` path plays 1.0 and 0.05 identically
- `Stop` cuts a sound short
- 2500 emits, half of them deliberately abandoned to the finalizer, with recipients disconnected mid-playback: resident memory did not grow

`SoundEventTests.cs` covers the packing, the parameter replacement, the integer type, the empty case and the hash agreement. I could not get the in-game xunit runner to report results in my environment, and the existing `RayTrace` and `UserMessage` tests behave identically there, so I ran the same assertions through an equivalent harness instead. Built and run on both platforms: gcc 13 on Linux, and MSVC 14.44 through the same `vsdevcmd` and CMake steps CI uses on `windows-latest`. The new files compile clean on both, with no warnings of their own. The checks listed above pass on a Linux server and on a Windows one running the MSVC build, including the hash agreement with the game.

## Not covered

`CMsgSosSetSoundEventParams` would let a playing sound be changed rather than only started and stopped, which is what a smooth fade needs. It reuses the same parameter blob and would be a small follow-up, left out here to keep this reviewable.

A sound name is resolved by the client, so a name that does not exist plays nothing and reports no error. The existing `EmitSound` behaves the same way. This is called out in the API documentation.

The discussion and the research behind it are @samyycX's, including the finding that the parameters are entirely net message based.



