### PR TITLE
Fix DropActivePlayerWeapon passing uninitialized vecDropMomentum

### DIFF
--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
@@ -34,8 +34,7 @@ public partial class CCSPlayer_ItemServices
 
         Guard.IsValidEntity(activeWeapon);
 
-        var dropMomentum = new Vector();
-        VirtualFunction.CreateVoid<nint, nint, nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_DropActivePlayerWeapon"))(Handle, activeWeapon.Handle, dropMomentum.Handle);
+        VirtualFunction.CreateVoid<nint, nint, nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_DropActivePlayerWeapon"))(Handle, activeWeapon.Handle, Vector.Zero.Handle);
     }
 
     /// <summary>

--- a/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
+++ b/managed/CounterStrikeSharp.API/Core/Model/CCSPlayer_ItemServices.cs
@@ -29,12 +29,13 @@ public partial class CCSPlayer_ItemServices
     /// <exception cref="InvalidOperationException">ItemServices points to null</exception>
     public void DropActivePlayerWeapon(CBasePlayerWeapon activeWeapon)
     {
-        if(Handle == IntPtr.Zero)
+        if (Handle == IntPtr.Zero)
             throw new InvalidOperationException("ItemServices points to null.");
 
         Guard.IsValidEntity(activeWeapon);
 
-        VirtualFunction.CreateVoid<nint, nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_DropActivePlayerWeapon"))(Handle, activeWeapon.Handle);
+        var dropMomentum = new Vector();
+        VirtualFunction.CreateVoid<nint, nint, nint>(Handle, GameData.GetOffset("CCSPlayer_ItemServices_DropActivePlayerWeapon"))(Handle, activeWeapon.Handle, dropMomentum.Handle);
     }
 
     /// <summary>


### PR DESCRIPTION
The vtable call for DropActivePlayerWeapon was missing the second parameter (const Vector& vecDropMomentum), so the native function read uninitialized stack for it — which could result in NaN entity velocity.

Passes an empty Vector to keep the public API stable, as suggested by @hzqst in the issue.

Tested on a live 1.0.373 server: weapon drops normally without abnormal velocity.

Closes #1214
